### PR TITLE
Add QLDPC-FIXTURE-002 frozen-corpus decoder benchmark

### DIFF
--- a/evidence/QLDPC-FIXTURE-002-report.json
+++ b/evidence/QLDPC-FIXTURE-002-report.json
@@ -94,7 +94,7 @@
   },
   "evaluator_version": "0.1.0",
   "fixture_id": "QLDPC-FIXTURE-002",
-  "payload_sha256": "f13522836c3fad9525984d8a99206343053f79af75494b4c6d7207d1075b41e9",
+  "payload_sha256": "d98c5d73f7fdf9259a35be60580dc9b6c32c5e4483cd765ed0dcba594b9299e5",
   "predecessor": {
     "evidence_path": "evidence/QLDPC-FIXTURE-001-report.json",
     "evidence_payload_sha256": "6c2095f48762178bf0fe5c2b5fce8299261733912a1cccc7884d11f344718427",
@@ -113,6 +113,8 @@
       "bp_method": "ms",
       "executed_by_fixture": false,
       "file": "18_4_4/ErrorCorrection_for_experiment_18_4_4.py",
+      "git_blob_sha": "df82b3a6aa17b969a50b1b143cc10136cb24547f",
+      "git_ref": "v1.1.3",
       "max_iter": 10000,
       "ms_scaling_factor": 0,
       "osd_method": "osd_cs",

--- a/evidence/QLDPC-FIXTURE-002-report.json
+++ b/evidence/QLDPC-FIXTURE-002-report.json
@@ -1,0 +1,130 @@
+{
+  "benchmark_results": {
+    "agreement": {
+      "corpus_size": 4048,
+      "same_correction_count": 2188,
+      "same_success_outcome_count": 3925
+    },
+    "exact_coset_lookup": {
+      "failure_total": 3808,
+      "success_counts_by_error_weight": {
+        "0": {"failure": 0, "success": 1, "total": 1},
+        "1": {"failure": 0, "success": 18, "total": 18},
+        "2": {"failure": 90, "success": 63, "total": 153},
+        "3": {"failure": 748, "success": 68, "total": 816},
+        "4": {"failure": 2970, "success": 90, "total": 3060}
+      },
+      "success_total": 240,
+      "systems_counters": {
+        "decode_input_syndrome_evaluations": 4048,
+        "decode_table_lookups": 4048,
+        "setup_candidate_errors_considered": 988,
+        "setup_syndrome_evaluations": 988,
+        "table_canonical_serialized_bytes": 8961,
+        "table_entries": 128
+      },
+      "table_sha256": "96ce94c378b7b1fc5fe032fbd253aa932c1ca8abcb17b3d3c89b3ecda601da29"
+    },
+    "greedy_syndrome_descent": {
+      "failure_total": 3923,
+      "failure_witnesses": [
+        {"correction": "000000000000000000", "error": "100000000010000000", "error_weight": 2, "input_syndrome": "000010100", "residual_error_weight": 2, "residual_syndrome": "000010100"},
+        {"correction": "000000000000000000", "error": "100000000000000100", "error_weight": 2, "input_syndrome": "010000001", "residual_error_weight": 2, "residual_syndrome": "010000001"},
+        {"correction": "000000000000000000", "error": "100000000000000010", "error_weight": 2, "input_syndrome": "100000010", "residual_error_weight": 2, "residual_syndrome": "100000010"},
+        {"correction": "100000100000000000", "error": "011000000000000000", "error_weight": 2, "input_syndrome": "110000011", "residual_error_weight": 4, "residual_syndrome": "000100001"},
+        {"correction": "100000000100000000", "error": "010000100000000000", "error_weight": 2, "input_syndrome": "011100100", "residual_error_weight": 4, "residual_syndrome": "000000000"},
+        {"correction": "100000100000000000", "error": "010000000100000000", "error_weight": 2, "input_syndrome": "110100010", "residual_error_weight": 4, "residual_syndrome": "000000000"},
+        {"correction": "000000000000000000", "error": "010000000001000000", "error_weight": 2, "input_syndrome": "000001010", "residual_error_weight": 2, "residual_syndrome": "000001010"},
+        {"correction": "100000000000000001", "error": "010000000000000100", "error_weight": 2, "input_syndrome": "111000111", "residual_error_weight": 4, "residual_syndrome": "000000000"},
+        {"correction": "000000000000000000", "error": "010000000000000010", "error_weight": 2, "input_syndrome": "001000100", "residual_error_weight": 2, "residual_syndrome": "001000100"},
+        {"correction": "000000000000000000", "error": "010000000000000001", "error_weight": 2, "input_syndrome": "010000001", "residual_error_weight": 2, "residual_syndrome": "010000001"},
+        {"correction": "010000000010000000", "error": "001000010000000000", "error_weight": 2, "input_syndrome": "101010010", "residual_error_weight": 4, "residual_syndrome": "000000000"},
+        {"correction": "100000000001000000", "error": "001000001000000000", "error_weight": 2, "input_syndrome": "101001100", "residual_error_weight": 4, "residual_syndrome": "000000000"}
+      ],
+      "success_counts_by_error_weight": {
+        "0": {"failure": 0, "success": 1, "total": 1},
+        "1": {"failure": 0, "success": 18, "total": 18},
+        "2": {"failure": 115, "success": 38, "total": 153},
+        "3": {"failure": 806, "success": 10, "total": 816},
+        "4": {"failure": 3002, "success": 58, "total": 3060}
+      },
+      "success_total": 125,
+      "systems_counters": {
+        "column_syndrome_table_canonical_serialized_bytes": 217,
+        "column_syndrome_table_sha256": "cf7e37ff1372a3e87d6bac17511f18e71229ef6c54167a2c2183c1a8414cf412",
+        "decode_candidate_comparisons": 150984,
+        "decode_input_syndrome_evaluations": 4048,
+        "decode_iterations_total": 6570,
+        "iteration_histogram": {"0": 478, "1": 702, "2": 2736, "3": 132},
+        "setup_column_syndrome_evaluations": 18,
+        "stalled_with_nonzero_syndrome": 1818
+      }
+    }
+  },
+  "claim_boundary": {
+    "autonomous_search_authorized": false,
+    "bp_osd_performance_claim": false,
+    "circuit_level_noise_claim": false,
+    "cross_machine_latency_claim": false,
+    "experimental_data_reproduction_claim": false,
+    "hardware_validation_claim": false,
+    "qldpc_forge_authorized": false,
+    "systems_benchmark_only": true,
+    "tcm_qdec_authorized": false,
+    "threshold_claim": false
+  },
+  "corpus": {
+    "actual_error_count": 4048,
+    "canonical_serialized_bytes": 170017,
+    "corpus_sha256": "260b1a43cf1d777f28c475918e91a5f7cefc5d28a2bfb556338f7e30058f58a8",
+    "expected_error_count": 4048,
+    "kind": "exhaustive_hamming_weight_shells",
+    "max_weight": 4,
+    "randomness": "none",
+    "sector_model": "code_capacity_single_css_sector",
+    "shell_sizes": {"0": 1, "1": 18, "2": 153, "3": 816, "4": 3060}
+  },
+  "deterministic_system_model": {
+    "data_bits": 18,
+    "full_syndrome_bits": 9,
+    "independent_syndrome_bits": 7,
+    "memory_metric": "canonical_serialized_bytes_not_runtime_object_size",
+    "stabilizer_span_size": 128,
+    "wall_clock_authoritative": false
+  },
+  "evaluator_version": "0.1.0",
+  "fixture_id": "QLDPC-FIXTURE-002",
+  "payload_sha256": "f13522836c3fad9525984d8a99206343053f79af75494b4c6d7207d1075b41e9",
+  "predecessor": {
+    "evidence_path": "evidence/QLDPC-FIXTURE-001-report.json",
+    "evidence_payload_sha256": "6c2095f48762178bf0fe5c2b5fce8299261733912a1cccc7884d11f344718427",
+    "fixture_id": "QLDPC-FIXTURE-001",
+    "promotion_merge_commit": "ab9a24a08d4e31b4d8cd18edb0ab1e5a7a0b3950",
+    "scientific_merge_commit": "b899894cfe17680d556d32ff36e51683cd9f6b32"
+  },
+  "source_context": {
+    "archive": {
+      "doi": "10.5281/zenodo.17706106",
+      "filename": "ZhideLu/Exp_BivariateBicycleCode-v1.1.3.zip",
+      "md5": "95c3421c0301e07266357652f0179d2b",
+      "version": "v1.1.3"
+    },
+    "experiment_decoder": {
+      "bp_method": "ms",
+      "executed_by_fixture": false,
+      "file": "18_4_4/ErrorCorrection_for_experiment_18_4_4.py",
+      "max_iter": 10000,
+      "ms_scaling_factor": 0,
+      "osd_method": "osd_cs",
+      "osd_order": 7
+    },
+    "software": {
+      "bposd": "1.6",
+      "ldpc": "0.1.53",
+      "leaky": "0.2.2",
+      "python": "3.10.14",
+      "stim": "1.13.0"
+    }
+  },
+  "status": "candidate_executable_not_promoted"
+}

--- a/reference/qldpc_fixture_002.py
+++ b/reference/qldpc_fixture_002.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""Deterministic systems benchmark for QLDPC-FIXTURE-002.
+
+Consumes the immutable QLDPC-FIXTURE-001 report, exhausts every single-sector
+error of weight 0..4, and compares an exact coset-leader lookup with a simple
+greedy syndrome-descent baseline. Wall-clock profiling is diagnostic only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import itertools
+import json
+import platform
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+EVALUATOR_VERSION = "0.1.0"
+PREDECESSOR = {
+    "fixture_id": "QLDPC-FIXTURE-001",
+    "evidence_path": "evidence/QLDPC-FIXTURE-001-report.json",
+    "evidence_payload_sha256": "6c2095f48762178bf0fe5c2b5fce8299261733912a1cccc7884d11f344718427",
+    "scientific_merge_commit": "b899894cfe17680d556d32ff36e51683cd9f6b32",
+    "promotion_merge_commit": "ab9a24a08d4e31b4d8cd18edb0ab1e5a7a0b3950",
+}
+CORPUS = {
+    "kind": "exhaustive_hamming_weight_shells",
+    "max_weight": 4,
+    "expected_error_count": 4048,
+    "sector_model": "code_capacity_single_css_sector",
+    "randomness": "none",
+}
+DECODERS = {
+    "exact_coset_lookup": {
+        "kind": "minimum_weight_coset_leader_table",
+        "expected_table_sha256": "96ce94c378b7b1fc5fe032fbd253aa932c1ca8abcb17b3d3c89b3ecda601da29",
+        "role": "exact_reference",
+    },
+    "greedy_syndrome_descent": {
+        "kind": "deterministic_best_syndrome_weight_reduction",
+        "max_iterations": 18,
+        "tie_break": "lowest_qubit_index",
+        "accept_only_strict_reduction": True,
+        "role": "simple_negative_capable_baseline",
+    },
+}
+SOURCE_CONTEXT = {
+    "archive": {
+        "doi": "10.5281/zenodo.17706106",
+        "version": "v1.1.3",
+        "filename": "ZhideLu/Exp_BivariateBicycleCode-v1.1.3.zip",
+        "md5": "95c3421c0301e07266357652f0179d2b",
+    },
+    "software": {
+        "python": "3.10.14",
+        "stim": "1.13.0",
+        "ldpc": "0.1.53",
+        "bposd": "1.6",
+        "leaky": "0.2.2",
+    },
+    "experiment_decoder": {
+        "file": "18_4_4/ErrorCorrection_for_experiment_18_4_4.py",
+        "bp_method": "ms",
+        "max_iter": 10000,
+        "osd_method": "osd_cs",
+        "osd_order": 7,
+        "ms_scaling_factor": 0,
+        "executed_by_fixture": False,
+    },
+}
+CLAIM_BOUNDARY = {
+    "systems_benchmark_only": True,
+    "experimental_data_reproduction_claim": False,
+    "circuit_level_noise_claim": False,
+    "bp_osd_performance_claim": False,
+    "hardware_validation_claim": False,
+    "threshold_claim": False,
+    "cross_machine_latency_claim": False,
+    "tcm_qdec_authorized": False,
+    "qldpc_forge_authorized": False,
+    "autonomous_search_authorized": False,
+}
+
+
+def cbytes(x: Any) -> bytes:
+    return json.dumps(x, sort_keys=True, separators=(",", ":"), ensure_ascii=True,
+                      allow_nan=False).encode("utf-8")
+
+
+def digest(x: Any) -> str:
+    return hashlib.sha256(cbytes(x)).hexdigest()
+
+
+canonical_digest = digest
+
+
+def keys(d: dict[str, Any], expected: set[str], where: str) -> None:
+    if set(d) != expected:
+        raise ValueError(
+            f"{where} key mismatch: missing={sorted(expected-set(d))}, "
+            f"extra={sorted(set(d)-expected)}"
+        )
+
+
+def b2i(s: str) -> int:
+    out = 0
+    for i, ch in enumerate(s):
+        if ch not in "01":
+            raise ValueError("non-binary bitstring")
+        if ch == "1":
+            out |= 1 << i
+    return out
+
+
+def i2b(v: int, w: int) -> str:
+    return "".join("1" if v & (1 << i) else "0" for i in range(w))
+
+
+def basis(vectors: list[int]) -> list[int]:
+    pivots: dict[int, int] = {}
+    for original in vectors:
+        v = original
+        while v:
+            p = v.bit_length() - 1
+            if p in pivots:
+                v ^= pivots[p]
+            else:
+                pivots[p] = v
+                break
+    return [pivots[p] for p in sorted(pivots, reverse=True)]
+
+
+def span(vectors: list[int]) -> set[int]:
+    out = {0}
+    for v in basis(vectors):
+        out |= {x ^ v for x in tuple(out)}
+    return out
+
+
+def syndrome(error: int, rows: list[int]) -> int:
+    out = 0
+    for i, row in enumerate(rows):
+        if (error & row).bit_count() & 1:
+            out |= 1 << i
+    return out
+
+
+def min_table(rows: list[int], n: int) -> tuple[dict[int, int], int]:
+    target = 1 << len(basis(rows))
+    table: dict[int, int] = {}
+    considered = 0
+    for weight in range(n + 1):
+        for support in itertools.combinations(range(n), weight):
+            error = sum(1 << q for q in support)
+            considered += 1
+            table.setdefault(syndrome(error, rows), error)
+        if len(table) == target:
+            break
+    if len(table) != target:
+        raise AssertionError("unreachable syndrome table target")
+    return table, considered
+
+
+def greedy(syn: int, columns: list[int], limit: int) -> tuple[int, int, int, int]:
+    correction = 0
+    residual = syn
+    iterations = comparisons = 0
+    while residual and iterations < limit:
+        current = residual.bit_count()
+        best_q = best_residual = None
+        best_reduction = 0
+        for q, column in enumerate(columns):
+            candidate = residual ^ column
+            comparisons += 1
+            reduction = current - candidate.bit_count()
+            if reduction > best_reduction:
+                best_reduction = reduction
+                best_q, best_residual = q, candidate
+        if best_q is None:
+            break
+        correction ^= 1 << best_q
+        residual = int(best_residual)
+        iterations += 1
+    return correction, residual, iterations, comparisons
+
+
+def root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def load_benchmark(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text())
+    keys(data, {"registry_version", "benchmarks"}, "registry")
+    if data["registry_version"] != "0.1.0" or not isinstance(data["benchmarks"], list):
+        raise ValueError("invalid benchmark registry")
+    matches = [x for x in data["benchmarks"] if x.get("fixture_id") == "QLDPC-FIXTURE-002"]
+    if len(matches) != 1:
+        raise ValueError("QLDPC-FIXTURE-002 must appear exactly once")
+    b = matches[0]
+    keys(b, {"claim_boundary", "corpus", "decoders", "fixture_id", "predecessor",
+             "programme", "source_context", "status"}, "benchmark")
+    if b["programme"] != "QTR" or b["status"] != "candidate_executable_not_promoted":
+        raise ValueError("benchmark identity/status changed")
+    for name, observed, expected in (
+        ("predecessor", b["predecessor"], PREDECESSOR),
+        ("corpus", b["corpus"], CORPUS),
+        ("decoders", b["decoders"], DECODERS),
+        ("source_context", b["source_context"], SOURCE_CONTEXT),
+        ("claim_boundary", b["claim_boundary"], CLAIM_BOUNDARY),
+    ):
+        if observed != expected:
+            raise ValueError(f"{name} unexpectedly changed")
+    return b
+
+
+def validate_predecessor(r: dict[str, Any]) -> tuple[list[int], list[int], set[int], int]:
+    keys(r, {"claim_boundary", "construction", "evaluator_version", "exact_invariants",
+             "fixture_id", "logical_basis", "payload_sha256", "reference_decoder",
+             "removed_checks_source_record", "source", "status"}, "predecessor report")
+    if r["fixture_id"] != PREDECESSOR["fixture_id"]:
+        raise ValueError("predecessor fixture mismatch")
+    if r["payload_sha256"] != PREDECESSOR["evidence_payload_sha256"]:
+        raise ValueError("predecessor payload mismatch")
+    unsigned = dict(r)
+    unsigned.pop("payload_sha256")
+    if digest(unsigned) != r["payload_sha256"]:
+        raise ValueError("predecessor payload does not self-verify")
+    if r["status"] != "candidate_executable_not_promoted":
+        raise ValueError("immutable predecessor status changed")
+    boundary = r["claim_boundary"]
+    if boundary.get("exact_code_algebra_only") is not True:
+        raise ValueError("predecessor exact algebra authority missing")
+    for name in ("decoder_performance_claim", "circuit_level_noise_claim",
+                 "hardware_validation_claim", "threshold_claim",
+                 "fault_tolerant_architecture_claim", "qldpc_forge_authorized",
+                 "tcm_qdec_authorized"):
+        if boundary.get(name) is not False:
+            raise ValueError(f"predecessor forbidden authority enabled: {name}")
+    c, inv, ref = r["construction"], r["exact_invariants"], r["reference_decoder"]
+    if c.get("family") != "bivariate_bicycle_css" or c.get("hx_equals_hz") is not True:
+        raise ValueError("predecessor construction changed")
+    if (inv.get("n"), inv.get("k"), inv.get("d"), inv.get("rank_hx"),
+        inv.get("rank_hz")) != (18, 4, 4, 7, 7) or inv.get("css_commutes") is not True:
+        raise ValueError("predecessor core invariants changed")
+    if ref.get("table_sha256") != DECODERS["exact_coset_lookup"]["expected_table_sha256"]:
+        raise ValueError("predecessor table identity changed")
+    hx_bits, hz_bits = c.get("hx"), c.get("hz")
+    if hx_bits != hz_bits or not isinstance(hx_bits, list) or len(hx_bits) != 9:
+        raise ValueError("predecessor matrices changed")
+    if any(not isinstance(row, str) or len(row) != 18 for row in hx_bits):
+        raise ValueError("predecessor matrix width changed")
+    hx, hz = [b2i(x) for x in hx_bits], [b2i(x) for x in hz_bits]
+    stabilizers = span(hx)
+    if len(basis(hx)) != 7 or len(basis(hz)) != 7 or len(stabilizers) != 128:
+        raise ValueError("predecessor rank/span changed")
+    return hx, hz, stabilizers, 18
+
+
+def make_corpus(n: int, max_weight: int) -> list[int]:
+    return [sum(1 << q for q in support)
+            for weight in range(max_weight + 1)
+            for support in itertools.combinations(range(n), weight)]
+
+
+def score(corpus: list[int], corrections: list[int], residuals: list[int],
+          stabilizers: set[int]) -> dict[str, dict[str, int]]:
+    out: dict[str, dict[str, int]] = {}
+    for error, correction, residual in zip(corpus, corrections, residuals):
+        bucket = out.setdefault(str(error.bit_count()), {"success": 0, "failure": 0, "total": 0})
+        ok = residual == 0 and (error ^ correction) in stabilizers
+        bucket["total"] += 1
+        bucket["success" if ok else "failure"] += 1
+    return out
+
+
+def evaluate(b: dict[str, Any], predecessor: dict[str, Any]) -> dict[str, Any]:
+    hx, hz, stabilizers, n = validate_predecessor(predecessor)
+    corpus = make_corpus(n, b["corpus"]["max_weight"])
+    if len(corpus) != b["corpus"]["expected_error_count"]:
+        raise AssertionError("corpus size mismatch")
+    corpus_records = [{"weight": e.bit_count(), "error": i2b(e, n)} for e in corpus]
+
+    table, considered = min_table(hz, n)
+    table_records = [{"syndrome": i2b(s, len(hz)), "correction": i2b(e, n),
+                      "weight": e.bit_count()} for s, e in sorted(table.items())]
+    table_sha = digest(table_records)
+    if table_sha != b["decoders"]["exact_coset_lookup"]["expected_table_sha256"]:
+        raise AssertionError("lookup table digest mismatch")
+
+    input_syndromes = [syndrome(e, hz) for e in corpus]
+    lookup_corrections = [table[s] for s in input_syndromes]
+    lookup_residuals = [syndrome(e ^ c, hz) for e, c in zip(corpus, lookup_corrections)]
+    lookup_counts = score(corpus, lookup_corrections, lookup_residuals, stabilizers)
+    predecessor_counts = {
+        w: {"success": v["success"], "failure": v["total"] - v["success"], "total": v["total"]}
+        for w, v in predecessor["reference_decoder"]["exact_success_counts_by_error_weight"].items()
+        if int(w) <= b["corpus"]["max_weight"]
+    }
+    if lookup_counts != predecessor_counts:
+        raise AssertionError("lookup results diverge from Fixture 001")
+
+    columns = [syndrome(1 << q, hz) for q in range(n)]
+    gcorr, gres = [], []
+    iterations = comparisons = stalled = 0
+    hist: dict[str, int] = {}
+    witnesses: list[dict[str, Any]] = []
+    for error, syn in zip(corpus, input_syndromes):
+        correction, residual, iters, comps = greedy(
+            syn, columns, b["decoders"]["greedy_syndrome_descent"]["max_iterations"]
+        )
+        gcorr.append(correction); gres.append(residual)
+        iterations += iters; comparisons += comps
+        hist[str(iters)] = hist.get(str(iters), 0) + 1
+        stalled += int(residual != 0)
+        ok = residual == 0 and (error ^ correction) in stabilizers
+        if not ok and len(witnesses) < 12:
+            witnesses.append({
+                "error_weight": error.bit_count(),
+                "error": i2b(error, n),
+                "input_syndrome": i2b(syn, len(hz)),
+                "correction": i2b(correction, n),
+                "residual_syndrome": i2b(residual, len(hz)),
+                "residual_error_weight": (error ^ correction).bit_count(),
+            })
+    greedy_counts = score(corpus, gcorr, gres, stabilizers)
+
+    same_correction = sum(a == b_ for a, b_ in zip(lookup_corrections, gcorr))
+    same_outcome = 0
+    for e, lc, lr, gc, gr in zip(corpus, lookup_corrections, lookup_residuals, gcorr, gres):
+        same_outcome += (
+            (lr == 0 and (e ^ lc) in stabilizers)
+            == (gr == 0 and (e ^ gc) in stabilizers)
+        )
+    column_bits = [i2b(x, len(hz)) for x in columns]
+    report: dict[str, Any] = {
+        "fixture_id": b["fixture_id"],
+        "evaluator_version": EVALUATOR_VERSION,
+        "status": b["status"],
+        "predecessor": b["predecessor"],
+        "corpus": {
+            **b["corpus"],
+            "actual_error_count": len(corpus),
+            "shell_sizes": {str(w): sum(e.bit_count() == w for e in corpus)
+                            for w in range(b["corpus"]["max_weight"] + 1)},
+            "corpus_sha256": digest(corpus_records),
+            "canonical_serialized_bytes": len(cbytes(corpus_records)),
+        },
+        "benchmark_results": {
+            "exact_coset_lookup": {
+                "success_counts_by_error_weight": lookup_counts,
+                "success_total": sum(x["success"] for x in lookup_counts.values()),
+                "failure_total": sum(x["failure"] for x in lookup_counts.values()),
+                "systems_counters": {
+                    "setup_candidate_errors_considered": considered,
+                    "setup_syndrome_evaluations": considered,
+                    "decode_input_syndrome_evaluations": len(corpus),
+                    "decode_table_lookups": len(corpus),
+                    "table_entries": len(table),
+                    "table_canonical_serialized_bytes": len(cbytes(table_records)),
+                },
+                "table_sha256": table_sha,
+            },
+            "greedy_syndrome_descent": {
+                "success_counts_by_error_weight": greedy_counts,
+                "success_total": sum(x["success"] for x in greedy_counts.values()),
+                "failure_total": sum(x["failure"] for x in greedy_counts.values()),
+                "systems_counters": {
+                    "setup_column_syndrome_evaluations": len(columns),
+                    "decode_input_syndrome_evaluations": len(corpus),
+                    "decode_iterations_total": iterations,
+                    "decode_candidate_comparisons": comparisons,
+                    "stalled_with_nonzero_syndrome": stalled,
+                    "iteration_histogram": dict(sorted(hist.items(), key=lambda x: int(x[0]))),
+                    "column_syndrome_table_canonical_serialized_bytes": len(cbytes(column_bits)),
+                    "column_syndrome_table_sha256": digest(column_bits),
+                },
+                "failure_witnesses": witnesses,
+            },
+            "agreement": {
+                "same_correction_count": same_correction,
+                "same_success_outcome_count": same_outcome,
+                "corpus_size": len(corpus),
+            },
+        },
+        "deterministic_system_model": {
+            "data_bits": n,
+            "full_syndrome_bits": len(hz),
+            "independent_syndrome_bits": len(basis(hz)),
+            "stabilizer_span_size": len(stabilizers),
+            "wall_clock_authoritative": False,
+            "memory_metric": "canonical_serialized_bytes_not_runtime_object_size",
+        },
+        "source_context": b["source_context"],
+        "claim_boundary": b["claim_boundary"],
+    }
+    report["payload_sha256"] = digest(report)
+    return report
+
+
+def profile(b: dict[str, Any], predecessor: dict[str, Any], repeats: int) -> dict[str, Any]:
+    if repeats <= 0:
+        raise ValueError("profile repeats must be positive")
+    samples = []
+    for _ in range(repeats):
+        start = time.perf_counter_ns()
+        evaluate(b, predecessor)
+        samples.append(time.perf_counter_ns() - start)
+    return {
+        "fixture_id": "QLDPC-FIXTURE-002",
+        "diagnostic_only": True,
+        "authoritative": False,
+        "python_version": sys.version.split()[0],
+        "platform": platform.platform(),
+        "repeats": repeats,
+        "elapsed_ns": samples,
+        "min_elapsed_ns": min(samples),
+        "max_elapsed_ns": max(samples),
+        "median_elapsed_ns": sorted(samples)[len(samples) // 2],
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--registry", type=Path, default=root() / "registry/qldpc-benchmarks.json")
+    p.add_argument("--predecessor", type=Path, default=root() / PREDECESSOR["evidence_path"])
+    p.add_argument("--output", type=Path)
+    p.add_argument("--profile-output", type=Path)
+    p.add_argument("--profile-repeats", type=int, default=3)
+    args = p.parse_args()
+    b = load_benchmark(args.registry)
+    predecessor = json.loads(args.predecessor.read_text())
+    report = evaluate(b, predecessor)
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered)
+    print(rendered, end="")
+    if args.profile_output:
+        args.profile_output.write_text(
+            json.dumps(profile(b, predecessor, args.profile_repeats), indent=2, sort_keys=True) + "\n"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reference/qldpc_fixture_002.py
+++ b/reference/qldpc_fixture_002.py
@@ -63,6 +63,8 @@ SOURCE_CONTEXT = {
     },
     "experiment_decoder": {
         "file": "18_4_4/ErrorCorrection_for_experiment_18_4_4.py",
+        "git_ref": "v1.1.3",
+        "git_blob_sha": "df82b3a6aa17b969a50b1b143cc10136cb24547f",
         "bp_method": "ms",
         "max_iter": 10000,
         "osd_method": "osd_cs",

--- a/registry/qldpc-benchmarks.json
+++ b/registry/qldpc-benchmarks.json
@@ -54,6 +54,8 @@
           "bp_method": "ms",
           "executed_by_fixture": false,
           "file": "18_4_4/ErrorCorrection_for_experiment_18_4_4.py",
+          "git_blob_sha": "df82b3a6aa17b969a50b1b143cc10136cb24547f",
+          "git_ref": "v1.1.3",
           "max_iter": 10000,
           "ms_scaling_factor": 0,
           "osd_method": "osd_cs",

--- a/registry/qldpc-benchmarks.json
+++ b/registry/qldpc-benchmarks.json
@@ -1,0 +1,74 @@
+{
+  "benchmarks": [
+    {
+      "claim_boundary": {
+        "autonomous_search_authorized": false,
+        "bp_osd_performance_claim": false,
+        "circuit_level_noise_claim": false,
+        "cross_machine_latency_claim": false,
+        "experimental_data_reproduction_claim": false,
+        "hardware_validation_claim": false,
+        "qldpc_forge_authorized": false,
+        "systems_benchmark_only": true,
+        "tcm_qdec_authorized": false,
+        "threshold_claim": false
+      },
+      "corpus": {
+        "expected_error_count": 4048,
+        "kind": "exhaustive_hamming_weight_shells",
+        "max_weight": 4,
+        "randomness": "none",
+        "sector_model": "code_capacity_single_css_sector"
+      },
+      "decoders": {
+        "exact_coset_lookup": {
+          "expected_table_sha256": "96ce94c378b7b1fc5fe032fbd253aa932c1ca8abcb17b3d3c89b3ecda601da29",
+          "kind": "minimum_weight_coset_leader_table",
+          "role": "exact_reference"
+        },
+        "greedy_syndrome_descent": {
+          "accept_only_strict_reduction": true,
+          "kind": "deterministic_best_syndrome_weight_reduction",
+          "max_iterations": 18,
+          "role": "simple_negative_capable_baseline",
+          "tie_break": "lowest_qubit_index"
+        }
+      },
+      "fixture_id": "QLDPC-FIXTURE-002",
+      "predecessor": {
+        "evidence_path": "evidence/QLDPC-FIXTURE-001-report.json",
+        "evidence_payload_sha256": "6c2095f48762178bf0fe5c2b5fce8299261733912a1cccc7884d11f344718427",
+        "fixture_id": "QLDPC-FIXTURE-001",
+        "promotion_merge_commit": "ab9a24a08d4e31b4d8cd18edb0ab1e5a7a0b3950",
+        "scientific_merge_commit": "b899894cfe17680d556d32ff36e51683cd9f6b32"
+      },
+      "programme": "QTR",
+      "source_context": {
+        "archive": {
+          "doi": "10.5281/zenodo.17706106",
+          "filename": "ZhideLu/Exp_BivariateBicycleCode-v1.1.3.zip",
+          "md5": "95c3421c0301e07266357652f0179d2b",
+          "version": "v1.1.3"
+        },
+        "experiment_decoder": {
+          "bp_method": "ms",
+          "executed_by_fixture": false,
+          "file": "18_4_4/ErrorCorrection_for_experiment_18_4_4.py",
+          "max_iter": 10000,
+          "ms_scaling_factor": 0,
+          "osd_method": "osd_cs",
+          "osd_order": 7
+        },
+        "software": {
+          "bposd": "1.6",
+          "ldpc": "0.1.53",
+          "leaky": "0.2.2",
+          "python": "3.10.14",
+          "stim": "1.13.0"
+        }
+      },
+      "status": "candidate_executable_not_promoted"
+    }
+  ],
+  "registry_version": "0.1.0"
+}

--- a/tests/test_qldpc_fixture_002.py
+++ b/tests/test_qldpc_fixture_002.py
@@ -1,0 +1,131 @@
+import copy
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "reference" / "qldpc_fixture_002.py"
+SPEC = importlib.util.spec_from_file_location("qldpc_fixture_002", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+class QLDPCFixture002Tests(unittest.TestCase):
+    def setUp(self):
+        self.registry_path = ROOT / "registry" / "qldpc-benchmarks.json"
+        self.predecessor_path = ROOT / "evidence" / "QLDPC-FIXTURE-001-report.json"
+        self.benchmark = MODULE.load_benchmark(self.registry_path)
+        self.predecessor = json.loads(self.predecessor_path.read_text(encoding="utf-8"))
+
+    def test_committed_evidence_exactly_replays(self):
+        observed = MODULE.evaluate(self.benchmark, self.predecessor)
+        expected = json.loads(
+            (ROOT / "evidence" / "QLDPC-FIXTURE-002-report.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        self.assertEqual(observed, expected)
+
+    def test_frozen_corpus_and_exact_lookup_match_predecessor(self):
+        report = MODULE.evaluate(self.benchmark, self.predecessor)
+        self.assertEqual(report["corpus"]["actual_error_count"], 4048)
+        self.assertEqual(
+            report["corpus"]["shell_sizes"],
+            {"0": 1, "1": 18, "2": 153, "3": 816, "4": 3060},
+        )
+        self.assertEqual(
+            report["corpus"]["corpus_sha256"],
+            "260b1a43cf1d777f28c475918e91a5f7cefc5d28a2bfb556338f7e30058f58a8",
+        )
+        exact = report["benchmark_results"]["exact_coset_lookup"]
+        self.assertEqual(exact["success_total"], 240)
+        self.assertEqual(exact["failure_total"], 3808)
+        self.assertEqual(
+            exact["table_sha256"],
+            self.predecessor["reference_decoder"]["table_sha256"],
+        )
+
+    def test_simple_decoder_retains_negative_evidence(self):
+        report = MODULE.evaluate(self.benchmark, self.predecessor)
+        greedy = report["benchmark_results"]["greedy_syndrome_descent"]
+        self.assertEqual(greedy["success_total"], 125)
+        self.assertEqual(greedy["failure_total"], 3923)
+        self.assertEqual(
+            greedy["success_counts_by_error_weight"]["2"],
+            {"success": 38, "failure": 115, "total": 153},
+        )
+        self.assertEqual(
+            greedy["systems_counters"]["stalled_with_nonzero_syndrome"], 1818
+        )
+        self.assertTrue(greedy["failure_witnesses"])
+
+    def test_systems_counters_are_deterministic_not_wall_clock_claims(self):
+        report = MODULE.evaluate(self.benchmark, self.predecessor)
+        exact = report["benchmark_results"]["exact_coset_lookup"]["systems_counters"]
+        greedy = report["benchmark_results"]["greedy_syndrome_descent"][
+            "systems_counters"
+        ]
+        self.assertEqual(exact["setup_candidate_errors_considered"], 988)
+        self.assertEqual(exact["decode_table_lookups"], 4048)
+        self.assertEqual(greedy["decode_iterations_total"], 6570)
+        self.assertEqual(greedy["decode_candidate_comparisons"], 150984)
+        self.assertFalse(report["deterministic_system_model"]["wall_clock_authoritative"])
+        self.assertFalse(report["source_context"]["experiment_decoder"]["executed_by_fixture"])
+
+    def test_predecessor_payload_tamper_fails_closed(self):
+        predecessor = copy.deepcopy(self.predecessor)
+        predecessor["payload_sha256"] = "0" * 64
+        with self.assertRaises(ValueError):
+            MODULE.evaluate(self.benchmark, predecessor)
+
+    def test_predecessor_authority_tamper_fails_closed(self):
+        predecessor = copy.deepcopy(self.predecessor)
+        predecessor["claim_boundary"]["threshold_claim"] = True
+        predecessor_without_digest = dict(predecessor)
+        predecessor_without_digest.pop("payload_sha256")
+        predecessor["payload_sha256"] = MODULE.canonical_digest(
+            predecessor_without_digest
+        )
+        with self.assertRaises(ValueError):
+            MODULE.evaluate(self.benchmark, predecessor)
+
+    def test_registry_corpus_tamper_fails_closed(self):
+        registry = json.loads(self.registry_path.read_text(encoding="utf-8"))
+        registry["benchmarks"][0]["corpus"]["max_weight"] = 5
+        path = ROOT / "tests" / ".tmp-qldpc-002-registry.json"
+        try:
+            path.write_text(json.dumps(registry), encoding="utf-8")
+            with self.assertRaises(ValueError):
+                MODULE.load_benchmark(path)
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_registry_downstream_authority_tamper_fails_closed(self):
+        registry = json.loads(self.registry_path.read_text(encoding="utf-8"))
+        registry["benchmarks"][0]["claim_boundary"]["tcm_qdec_authorized"] = True
+        path = ROOT / "tests" / ".tmp-qldpc-002-authority.json"
+        try:
+            path.write_text(json.dumps(registry), encoding="utf-8")
+            with self.assertRaises(ValueError):
+                MODULE.load_benchmark(path)
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_source_context_tamper_fails_closed(self):
+        registry = json.loads(self.registry_path.read_text(encoding="utf-8"))
+        registry["benchmarks"][0]["source_context"]["experiment_decoder"][
+            "osd_order"
+        ] = 8
+        path = ROOT / "tests" / ".tmp-qldpc-002-source.json"
+        try:
+            path.write_text(json.dumps(registry), encoding="utf-8")
+            with self.assertRaises(ValueError):
+                MODULE.load_benchmark(path)
+        finally:
+            path.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/work-packages/QTR-QLDPC-FIXTURE-002.md
+++ b/work-packages/QTR-QLDPC-FIXTURE-002.md
@@ -1,0 +1,206 @@
+# QTR-QLDPC-FIXTURE-002 — Frozen-corpus decoder systems benchmark
+
+Status: `candidate_executable_not_promoted`
+
+Programme: `GCL Quantum Technologies Research (QTR)`
+
+Fixture identifier: `QLDPC-FIXTURE-002`
+
+Predecessor: `QLDPC-FIXTURE-001`
+
+Tracking issue: `#32`
+
+## 1. Purpose
+
+This work package establishes the first systems-measurement layer above the
+promoted finite qLDPC algebra substrate.
+
+The benchmark intentionally stays on the same protected `[[18,4,4]]`
+bivariate-bicycle CSS code. Its purpose is to make decoder correctness,
+negative evidence, deterministic cost counters, and benchmark provenance
+machine-checkable before any broader decoder or architecture programme is
+allowed to begin.
+
+It is not a decoder competition and it is not a circuit-level or hardware
+reproduction.
+
+## 2. Predecessor binding
+
+The evaluator consumes the immutable Fixture 001 evidence snapshot:
+
+- evidence path: `evidence/QLDPC-FIXTURE-001-report.json`;
+- evidence payload:
+  `6c2095f48762178bf0fe5c2b5fce8299261733912a1cccc7884d11f344718427`;
+- scientific merge:
+  `b899894cfe17680d556d32ff36e51683cd9f6b32`;
+- promotion pin:
+  `ab9a24a08d4e31b4d8cd18edb0ab1e5a7a0b3950`.
+
+Fixture 002 re-verifies the predecessor payload digest and core algebraic
+identities before benchmarking. It does not reinterpret the documentary
+promotion overlay as new mathematical evidence.
+
+## 3. Frozen corpus
+
+The benchmark corpus is exhaustive rather than sampled.
+
+For one CSS sector it contains every 18-bit error of Hamming weight
+
+\[
+0\leq w\leq 4.
+\]
+
+The shell sizes are
+
+\[
+\binom{18}{0}=1,\quad
+\binom{18}{1}=18,\quad
+\binom{18}{2}=153,\quad
+\binom{18}{3}=816,\quad
+\binom{18}{4}=3060,
+\]
+
+for a total of `4048` error instances.
+
+No random seed exists because no random sampling is performed. The complete
+ordered corpus is represented by a canonical SHA-256 identity in the evidence
+report.
+
+Because Fixture 001 has `H_X = H_Z`, the same finite parity-check structure can
+be reused for either code-capacity CSS sector. Fixture 002 nevertheless reports
+one sector only and does not multiply this finite benchmark into a
+circuit-level noise claim.
+
+## 4. Decoder baselines
+
+Two deliberately different baselines are included.
+
+### 4.1 Exact coset-leader lookup
+
+The first baseline reconstructs the exhaustive minimum-weight syndrome table
+used in Fixture 001.
+
+It is an exact finite reference object, not a scalable decoder proposal. Its
+table digest must remain
+
+`96ce94c378b7b1fc5fe032fbd253aa932c1ca8abcb17b3d3c89b3ecda601da29`.
+
+Every benchmark result is scored by checking the residual error modulo the
+certified X-stabilizer span, not by trusting the decoder's own termination
+state.
+
+### 4.2 Greedy syndrome descent
+
+The second baseline is intentionally simple.
+
+At each iteration it evaluates all 18 single-qubit flips and chooses the
+lowest-index qubit that gives the largest strict reduction in syndrome Hamming
+weight. If no strict reduction exists, it stops and retains the nonzero
+residual syndrome as negative evidence.
+
+This decoder is included because a systems fixture should be able to preserve
+failures, not because the algorithm is expected to be competitive.
+
+## 5. Deterministic systems counters
+
+Committed evidence contains deterministic counters rather than
+machine-dependent timing claims.
+
+The report records, among other quantities:
+
+- exact lookup-table setup candidate count;
+- syndrome evaluations;
+- table lookups;
+- greedy iterations;
+- greedy candidate comparisons;
+- stalled nonzero syndromes;
+- iteration histogram;
+- canonical serialized byte sizes for the lookup and column-syndrome tables.
+
+These quantities replay exactly on any conforming Python implementation.
+
+An optional `--profile-output` mode may record wall-clock timing together with
+the Python and platform identity. Such output is explicitly diagnostic,
+non-authoritative, and is not included in the committed evidence payload.
+
+## 6. Source-context record
+
+The registry also binds the companion experimental software as provenance
+context only:
+
+- Zenodo DOI `10.5281/zenodo.17706106`;
+- archive version `v1.1.3`;
+- archive MD5 `95c3421c0301e07266357652f0179d2b`;
+- Python `3.10.14`;
+- Stim `1.13.0`;
+- LDPC `0.1.53`;
+- bposd `1.6`;
+- leaky `0.2.2`.
+
+The source experiment decoder
+`18_4_4/ErrorCorrection_for_experiment_18_4_4.py` records min-sum BP,
+`max_iter=10000`, `osd_cs`, OSD order `7`, and min-sum scaling factor `0`.
+
+Fixture 002 does **not** execute that BP-OSD pipeline. The transcription exists
+to establish a future compatibility boundary, not to import the source
+experiment's decoder performance into GCL authority.
+
+## 7. Evidence and replay
+
+The deterministic report is regenerated with
+
+```bash
+python reference/qldpc_fixture_002.py \
+  --output evidence/QLDPC-FIXTURE-002-report.json
+```
+
+Optional machine-local timing diagnostics may be produced separately:
+
+```bash
+python reference/qldpc_fixture_002.py \
+  --profile-output /tmp/QLDPC-FIXTURE-002-profile.json
+```
+
+The test package must verify exact committed replay and adversarially reject
+changes to the predecessor payload, predecessor claim boundary, corpus
+definition, source-context record, or downstream authorization flags.
+
+## 8. Claim boundary
+
+Fixture 002 may seek promotion only for:
+
+- this frozen finite code-capacity corpus;
+- exact correctness scoring against the promoted Fixture 001 algebra;
+- the two explicitly named deterministic decoder baselines;
+- deterministic systems counters and preserved negative evidence;
+- non-authoritative optional local profiling mechanics.
+
+It does **not** certify or authorize:
+
+- experimental-data reproduction;
+- circuit-level or Pauli+ noise-model validation;
+- BP-OSD performance or superiority;
+- Kunlun hardware validation;
+- thresholds or pseudo-thresholds;
+- cross-machine latency comparisons;
+- practical decoder/resource superiority;
+- fault-tolerant logical operations;
+- `TCM-QDEC`;
+- `QLDPC-FORGE`;
+- autonomous code, decoder, circuit, or architecture search.
+
+## 9. Promotion condition
+
+Promotion requires:
+
+1. exact predecessor binding and replay;
+2. byte-stable deterministic evidence regeneration;
+3. exhaustive corpus identity and shell counts;
+4. exact lookup results equal to Fixture 001;
+5. retained simple-decoder failures and witnesses;
+6. exact deterministic systems counters;
+7. green adversarial tests;
+8. exact-head QTR and GCL workflows;
+9. a fresh bounded office review and Referee disposition.
+
+Until then, Fixture 002 remains executable candidate evidence only.


### PR DESCRIPTION
## Subject

Advance only `QLDPC-FIXTURE-002` above the promoted Fixture 001 substrate.

This candidate adds a deterministic same-code systems benchmark on the protected `[[18,4,4]]` bivariate-bicycle CSS fixture. It does not open `TCM-QDEC` or `QLDPC-FORGE`.

## Current exact subject — revision 2

- protected base: `ab9a24a08d4e31b4d8cd18edb0ab1e5a7a0b3950`
- candidate head: `e7b2eb0060e51d4157a6666f2e857c1fb19aaff1`
- tracking issue: #32
- predecessor evidence payload: `6c2095f48762178bf0fe5c2b5fce8299261733912a1cccc7884d11f344718427`
- candidate evidence payload: `d98c5d73f7fdf9259a35be60580dc9b6c32c5e4483cd765ed0dcba594b9299e5`
- frozen corpus: all single-sector errors of Hamming weight 0 through 4, `4048` total, corpus SHA-256 `260b1a43cf1d777f28c475918e91a5f7cefc5d28a2bfb556338f7e30058f58a8`

The prior head `37e96d9587fc712d69b653e8dc1559e970b2f439` and its green workflows are historical only. Revision 2 strengthens source-context provenance by binding the companion experimental decoder file to Git tag `v1.1.3` and blob `df82b3a6aa17b969a50b1b143cc10136cb24547f`. No benchmark output or deterministic counter changed.

## Benchmark subjects

1. Fixture 001 exact minimum-weight coset-leader lookup, reconstructed and digest-bound.
2. A deterministic greedy syndrome-descent baseline that accepts only strict syndrome-weight reductions and uses lowest-qubit-index tie breaking.

The exact lookup reproduces Fixture 001's finite counts. The greedy baseline deliberately retains negative evidence: it succeeds on 125/4048 corpus elements, including all 18 weight-one errors, and stalls with nonzero syndrome on 1818 cases.

## Deterministic systems evidence

The committed report contains exact operation/storage counters rather than machine-dependent timing claims. Optional wall-clock profiling is emitted only to a separate non-authoritative diagnostic file.

## Source context

The registry binds the companion experimental software archive at Zenodo `10.5281/zenodo.17706106`, version `v1.1.3`, and records its published software/BP-OSD configuration as provenance context only. The exact experimental-decoder source path is additionally bound to tag `v1.1.3`, Git blob `df82b3a6aa17b969a50b1b143cc10136cb24547f`. Fixture 002 does not execute or validate that experimental decoder pipeline.

## Claim boundary

No experimental-data reproduction, circuit-level or Pauli+ validation, BP-OSD performance claim, hardware validation, threshold claim, cross-machine latency claim, practical decoder superiority, fault-tolerant logical-operation authority, `TCM-QDEC`, `QLDPC-FORGE`, or autonomous search authority is created.

## Review gate

Keep this PR draft until fresh revision-2 exact-head QTR/GCL replay proves:

- predecessor payload self-verification;
- committed evidence regeneration;
- exhaustive corpus identity;
- exact lookup equality with Fixture 001;
- deterministic systems counters;
- tagged source-context binding;
- adversarial fail-closed behavior for predecessor, corpus, source-context, and downstream-authority mutations.