### PR TITLE
Add TCM-QDEC-001 degeneracy-aware semiring audit

### DIFF
--- a/evidence/TCM-QDEC-001-report.json
+++ b/evidence/TCM-QDEC-001-report.json
@@ -1,0 +1,446 @@
+{
+  "claim_boundary": {
+    "autonomous_search_authorized": false,
+    "bp_osd_performance_claim": false,
+    "circuit_level_noise_claim": false,
+    "decoder_performance_superiority_claim": false,
+    "exact_state_space_enumeration": true,
+    "finite_semiring_comparison_only": true,
+    "frozen_fixture_002_corpus_only": true,
+    "general_qldpc_decoder_claim": false,
+    "hardware_validation_claim": false,
+    "learned_decoder_authorized": false,
+    "portable_latency_or_memory_claim": false,
+    "qldpc_forge_authorized": false,
+    "scalable_tensor_contraction_claim": false,
+    "tcm_qdec_002_authorized": false,
+    "threshold_claim": false
+  },
+  "comparisons": {
+    "min_plus_hamming": {
+      "quotient_minus_fixture_002_exact_success_count": -14,
+      "quotient_minus_fixture_002_greedy_success_count": 101,
+      "quotient_minus_representative_success_count": 189,
+      "quotient_vs_fixture_002_exact": {
+        "broken_by_second": 110,
+        "repaired_by_second": 96,
+        "same_outcome": 3842
+      },
+      "quotient_vs_fixture_002_greedy": {
+        "broken_by_second": 49,
+        "repaired_by_second": 150,
+        "same_outcome": 3849
+      },
+      "quotient_vs_representative": {
+        "broken_by_second": 0,
+        "broken_witnesses": [],
+        "repaired_by_second": 189,
+        "repaired_witnesses": [
+          {
+            "error": "110000000000000000",
+            "error_weight": 2,
+            "first_correction": "000000000000000000",
+            "second_correction": "110000000000000000",
+            "syndrome": "101000110"
+          },
+          {
+            "error": "101000000000000000",
+            "error_weight": 2,
+            "first_correction": "000000000000000000",
+            "second_correction": "101000000000000000",
+            "syndrome": "011000101"
+          },
+          {
+            "error": "100100000000000000",
+            "error_weight": 2,
+            "first_correction": "000000000000000000",
+            "second_correction": "100100000000000000",
+            "syndrome": "010110100"
+          },
+          {
+            "error": "100010000000000000",
+            "error_weight": 2,
+            "first_correction": "000000000000000000",
+            "second_correction": "100010000000000000",
+            "syndrome": "100011100"
+          }
+        ],
+        "same_outcome": 3859
+      }
+    },
+    "soft_tropical_base_2": {
+      "quotient_minus_fixture_002_exact_success_count": 22,
+      "quotient_minus_fixture_002_greedy_success_count": 137,
+      "quotient_minus_representative_success_count": 261,
+      "quotient_vs_fixture_002_exact": {
+        "broken_by_second": 108,
+        "repaired_by_second": 130,
+        "same_outcome": 3810
+      },
+      "quotient_vs_fixture_002_greedy": {
+        "broken_by_second": 49,
+        "repaired_by_second": 186,
+        "same_outcome": 3813
+      },
+      "quotient_vs_representative": {
+        "broken_by_second": 0,
+        "broken_witnesses": [],
+        "repaired_by_second": 261,
+        "repaired_witnesses": [
+          {
+            "error": "100000000000000000",
+            "error_weight": 1,
+            "first_correction": "000000000000000000",
+            "second_correction": "100000000000000000",
+            "syndrome": "110000100"
+          },
+          {
+            "error": "010000000000000000",
+            "error_weight": 1,
+            "first_correction": "000000000000000000",
+            "second_correction": "010000000000000000",
+            "syndrome": "011000010"
+          },
+          {
+            "error": "001000000000000000",
+            "error_weight": 1,
+            "first_correction": "000000000000000000",
+            "second_correction": "001000000000000000",
+            "syndrome": "101000001"
+          },
+          {
+            "error": "000100000000000000",
+            "error_weight": 1,
+            "first_correction": "000000000000000000",
+            "second_correction": "000100000000000000",
+            "syndrome": "100110000"
+          }
+        ],
+        "same_outcome": 3787
+      }
+    },
+    "sum_product_bsc_p_0_1": {
+      "quotient_minus_fixture_002_exact_success_count": 23,
+      "quotient_minus_fixture_002_greedy_success_count": 138,
+      "quotient_minus_representative_success_count": 226,
+      "quotient_vs_fixture_002_exact": {
+        "broken_by_second": 108,
+        "repaired_by_second": 131,
+        "same_outcome": 3809
+      },
+      "quotient_vs_fixture_002_greedy": {
+        "broken_by_second": 49,
+        "repaired_by_second": 187,
+        "same_outcome": 3812
+      },
+      "quotient_vs_representative": {
+        "broken_by_second": 0,
+        "broken_witnesses": [],
+        "repaired_by_second": 226,
+        "repaired_witnesses": [
+          {
+            "error": "110000000000000000",
+            "error_weight": 2,
+            "first_correction": "000000000000000000",
+            "second_correction": "110000000000000000",
+            "syndrome": "101000110"
+          },
+          {
+            "error": "101000000000000000",
+            "error_weight": 2,
+            "first_correction": "000000000000000000",
+            "second_correction": "101000000000000000",
+            "syndrome": "011000101"
+          },
+          {
+            "error": "100100000000000000",
+            "error_weight": 2,
+            "first_correction": "000000000000000000",
+            "second_correction": "100100000000000000",
+            "syndrome": "010110100"
+          },
+          {
+            "error": "100010000000000000",
+            "error_weight": 2,
+            "first_correction": "000000000000000000",
+            "second_correction": "100010000000000000",
+            "syndrome": "100011100"
+          }
+        ],
+        "same_outcome": 3822
+      }
+    }
+  },
+  "evaluator_version": "0.1.0",
+  "experiment_id": "TCM-QDEC-001",
+  "fixture_002_baselines": {
+    "exact_coset_lookup": {
+      "failure_modes": {
+        "nonzero_residual_syndrome": 0,
+        "zero_syndrome_wrong_logical_coset": 3808
+      },
+      "failure_total": 3808,
+      "success_by_error_weight": {
+        "0": 1,
+        "1": 18,
+        "2": 63,
+        "3": 68,
+        "4": 90
+      },
+      "success_total": 240
+    },
+    "greedy_syndrome_descent": {
+      "failure_modes": {
+        "nonzero_residual_syndrome": 1818,
+        "zero_syndrome_wrong_logical_coset": 2105
+      },
+      "failure_total": 3923,
+      "success_by_error_weight": {
+        "0": 1,
+        "1": 18,
+        "2": 38,
+        "3": 10,
+        "4": 58
+      },
+      "success_total": 125
+    }
+  },
+  "inference_matrix": {
+    "representative_naive_marginals": {
+      "min_plus_hamming": {
+        "decision_diagnostics": {
+          "decision_table_sha256": "d70b3950bc18ad2c89edf684e5b2d771c89c308a193c8f9c29850c8ac5ba1c26",
+          "decision_tie_syndromes": 91,
+          "syndrome_invalid_decisions": 91,
+          "syndrome_valid_decisions": 37,
+          "unique_syndrome_decisions": 128
+        },
+        "failure_modes": {
+          "nonzero_residual_syndrome": 2796,
+          "zero_syndrome_wrong_logical_coset": 1215
+        },
+        "failure_total": 4011,
+        "success_by_error_weight": {
+          "0": 1,
+          "1": 18,
+          "2": 18,
+          "3": 0,
+          "4": 0
+        },
+        "success_total": 37
+      },
+      "soft_tropical_base_2": {
+        "decision_diagnostics": {
+          "decision_table_sha256": "c53fb4d9e07394bcff16ed2d15296468092556b4e6e2041ae43036d88f907914",
+          "decision_tie_syndromes": 0,
+          "syndrome_invalid_decisions": 127,
+          "syndrome_valid_decisions": 1,
+          "unique_syndrome_decisions": 128
+        },
+        "failure_modes": {
+          "nonzero_residual_syndrome": 4002,
+          "zero_syndrome_wrong_logical_coset": 45
+        },
+        "failure_total": 4047,
+        "success_by_error_weight": {
+          "0": 1,
+          "1": 0,
+          "2": 0,
+          "3": 0,
+          "4": 0
+        },
+        "success_total": 1
+      },
+      "sum_product_bsc_p_0_1": {
+        "decision_diagnostics": {
+          "decision_table_sha256": "d70b3950bc18ad2c89edf684e5b2d771c89c308a193c8f9c29850c8ac5ba1c26",
+          "decision_tie_syndromes": 0,
+          "syndrome_invalid_decisions": 91,
+          "syndrome_valid_decisions": 37,
+          "unique_syndrome_decisions": 128
+        },
+        "failure_modes": {
+          "nonzero_residual_syndrome": 2796,
+          "zero_syndrome_wrong_logical_coset": 1215
+        },
+        "failure_total": 4011,
+        "success_by_error_weight": {
+          "0": 1,
+          "1": 18,
+          "2": 18,
+          "3": 0,
+          "4": 0
+        },
+        "success_total": 37
+      }
+    },
+    "stabilizer_coset_aggregate": {
+      "min_plus_hamming": {
+        "decision_diagnostics": {
+          "decision_table_sha256": "88a9a766b64c7e476ac5bb4da877a2b1f6d4e88cee88cde6ea7461cc74179f3f",
+          "decision_tie_syndromes": 91,
+          "syndrome_invalid_decisions": 0,
+          "syndrome_valid_decisions": 128,
+          "unique_syndrome_decisions": 128
+        },
+        "failure_modes": {
+          "nonzero_residual_syndrome": 0,
+          "zero_syndrome_wrong_logical_coset": 3822
+        },
+        "failure_total": 3822,
+        "success_by_error_weight": {
+          "0": 1,
+          "1": 18,
+          "2": 63,
+          "3": 54,
+          "4": 90
+        },
+        "success_total": 226
+      },
+      "soft_tropical_base_2": {
+        "decision_diagnostics": {
+          "decision_table_sha256": "ea2a96e3878758cd2daebd28673d943c27740a3e1c3579d8429a8a658e567393",
+          "decision_tie_syndromes": 91,
+          "syndrome_invalid_decisions": 0,
+          "syndrome_valid_decisions": 128,
+          "unique_syndrome_decisions": 128
+        },
+        "failure_modes": {
+          "nonzero_residual_syndrome": 0,
+          "zero_syndrome_wrong_logical_coset": 3786
+        },
+        "failure_total": 3786,
+        "success_by_error_weight": {
+          "0": 1,
+          "1": 18,
+          "2": 63,
+          "3": 90,
+          "4": 90
+        },
+        "success_total": 262
+      },
+      "sum_product_bsc_p_0_1": {
+        "decision_diagnostics": {
+          "decision_table_sha256": "05dd32573ee965ce96caf707de3541f8be74b49317ad46b7929ef7dcf3bf64fc",
+          "decision_tie_syndromes": 91,
+          "syndrome_invalid_decisions": 0,
+          "syndrome_valid_decisions": 128,
+          "unique_syndrome_decisions": 128
+        },
+        "failure_modes": {
+          "nonzero_residual_syndrome": 0,
+          "zero_syndrome_wrong_logical_coset": 3785
+        },
+        "failure_total": 3785,
+        "success_by_error_weight": {
+          "0": 1,
+          "1": 18,
+          "2": 63,
+          "3": 91,
+          "4": 90
+        },
+        "success_total": 263
+      }
+    }
+  },
+  "payload_sha256": "1b19addcda5e04cf78a834b2162fe0873ed5eb15f3330995d8354906944b7122",
+  "predecessor": {
+    "corpus_sha256": "260b1a43cf1d777f28c475918e91a5f7cefc5d28a2bfb556338f7e30058f58a8",
+    "evidence_path": "evidence/QLDPC-FIXTURE-002-report.json",
+    "evidence_payload_sha256": "d98c5d73f7fdf9259a35be60580dc9b6c32c5e4483cd765ed0dcba594b9299e5",
+    "fixture_id": "QLDPC-FIXTURE-002",
+    "promotion_merge_commit": "074612e39e1232d1644edc487914ca571189f409",
+    "promotion_record_path": "reviews/QTR-QLDPC-REVIEW-002/promotion-record.json",
+    "scientific_merge_commit": "51c31bde2e0630314d3d48dceb9b92969c37c228"
+  },
+  "quotient_treatments": {
+    "representative_naive_marginals": {
+      "kind": "coordinatewise_semiring_marginal_hard_decision",
+      "syndrome_projection": "none",
+      "tie_break": "zero_bit"
+    },
+    "stabilizer_coset_aggregate": {
+      "class_tie_break": "lowest_canonical_coset_key",
+      "kind": "semiring_aggregate_over_stabilizer_equivalence_class",
+      "representative_within_class": "lowest_hamming_weight_then_integer"
+    }
+  },
+  "semirings": {
+    "min_plus_hamming": {
+      "exact_state_weight": "hamming_weight",
+      "interpretation": "minimum Hamming-weight tropical score",
+      "kind": "min_plus",
+      "score_direction": "minimize"
+    },
+    "soft_tropical_base_2": {
+      "exact_state_weight": "2**(n-hamming_weight)",
+      "interpretation": "exact partition score equivalent in ranking to beta=ln(2) soft-min",
+      "kind": "soft_tropical",
+      "score_direction": "maximize"
+    },
+    "sum_product_bsc_p_0_1": {
+      "exact_state_weight": "9**(n-hamming_weight)",
+      "interpretation": "exact numerator proportional to BSC p=0.1 likelihood",
+      "kind": "sum_product",
+      "score_direction": "maximize"
+    }
+  },
+  "state_space": {
+    "corpus_kind": "fixture_002_frozen_hamming_weight_0_through_4",
+    "corpus_sha256": "260b1a43cf1d777f28c475918e91a5f7cefc5d28a2bfb556338f7e30058f58a8",
+    "corpus_size": 4048,
+    "full_physical_error_states": 262144,
+    "full_state_enumeration_count": 262144,
+    "logical_cosets_per_syndrome": 16,
+    "reachable_syndromes": 128,
+    "replayed_corpus_sha256": "260b1a43cf1d777f28c475918e91a5f7cefc5d28a2bfb556338f7e30058f58a8",
+    "sector_model": "code_capacity_single_css_sector",
+    "stabilizer_span_size": 128,
+    "states_per_syndrome": 2048
+  },
+  "status": "candidate_executable_not_promoted",
+  "tie_sensitivity": {
+    "min_plus_hamming": {
+      "default_lowest_key_success_count": 226,
+      "frozen_corpus_success_count_envelope_over_winning_class_ties": {
+        "max": 263,
+        "min": 218
+      },
+      "success_count_invariant_under_winning_class_tie_break": false,
+      "winning_class_count_histogram": {
+        "1": 37,
+        "10": 45,
+        "3": 45,
+        "6": 1
+      }
+    },
+    "soft_tropical_base_2": {
+      "default_lowest_key_success_count": 262,
+      "frozen_corpus_success_count_envelope_over_winning_class_ties": {
+        "max": 262,
+        "min": 262
+      },
+      "success_count_invariant_under_winning_class_tie_break": true,
+      "winning_class_count_histogram": {
+        "1": 37,
+        "10": 1,
+        "3": 45,
+        "4": 45
+      }
+    },
+    "sum_product_bsc_p_0_1": {
+      "default_lowest_key_success_count": 263,
+      "frozen_corpus_success_count_envelope_over_winning_class_ties": {
+        "max": 263,
+        "min": 263
+      },
+      "success_count_invariant_under_winning_class_tie_break": true,
+      "winning_class_count_histogram": {
+        "1": 37,
+        "3": 45,
+        "4": 45,
+        "6": 1
+      }
+    }
+  }
+}

--- a/reference/tcm_qdec_001.py
+++ b/reference/tcm_qdec_001.py
@@ -1,0 +1,555 @@
+#!/usr/bin/env python3
+"""TCM-QDEC-001: exact finite degeneracy-aware semiring inference audit."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+F2_PATH = ROOT / "reference" / "qldpc_fixture_002.py"
+SPEC = importlib.util.spec_from_file_location("qldpc_fixture_002_for_tcm", F2_PATH)
+F2 = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(F2)
+
+EVALUATOR_VERSION = "0.1.0"
+FIXTURE_001_PAYLOAD = "6c2095f48762178bf0fe5c2b5fce8299261733912a1cccc7884d11f344718427"
+FIXTURE_002_PAYLOAD = "d98c5d73f7fdf9259a35be60580dc9b6c32c5e4483cd765ed0dcba594b9299e5"
+FIXTURE_002_CORPUS = "260b1a43cf1d777f28c475918e91a5f7cefc5d28a2bfb556338f7e30058f58a8"
+FIXTURE_002_SCIENTIFIC_MERGE = "51c31bde2e0630314d3d48dceb9b92969c37c228"
+FIXTURE_002_PROMOTION_MERGE = "074612e39e1232d1644edc487914ca571189f409"
+EXACT_TABLE_SHA = "96ce94c378b7b1fc5fe032fbd253aa932c1ca8abcb17b3d3c89b3ecda601da29"
+
+CLAIM_BOUNDARY = {
+    "finite_semiring_comparison_only": True,
+    "frozen_fixture_002_corpus_only": True,
+    "exact_state_space_enumeration": True,
+    "scalable_tensor_contraction_claim": False,
+    "general_qldpc_decoder_claim": False,
+    "decoder_performance_superiority_claim": False,
+    "bp_osd_performance_claim": False,
+    "circuit_level_noise_claim": False,
+    "hardware_validation_claim": False,
+    "threshold_claim": False,
+    "portable_latency_or_memory_claim": False,
+    "learned_decoder_authorized": False,
+    "tcm_qdec_002_authorized": False,
+    "qldpc_forge_authorized": False,
+    "autonomous_search_authorized": False,
+}
+
+SEMIRINGS = {
+    "sum_product_bsc_p_0_1": {
+        "kind": "sum_product",
+        "score_direction": "maximize",
+        "exact_state_weight": "9**(n-hamming_weight)",
+        "interpretation": "exact numerator proportional to BSC p=0.1 likelihood",
+    },
+    "soft_tropical_base_2": {
+        "kind": "soft_tropical",
+        "score_direction": "maximize",
+        "exact_state_weight": "2**(n-hamming_weight)",
+        "interpretation": "exact partition score equivalent in ranking to beta=ln(2) soft-min",
+    },
+    "min_plus_hamming": {
+        "kind": "min_plus",
+        "score_direction": "minimize",
+        "exact_state_weight": "hamming_weight",
+        "interpretation": "minimum Hamming-weight tropical score",
+    },
+}
+
+TREATMENTS = {
+    "representative_naive_marginals": {
+        "kind": "coordinatewise_semiring_marginal_hard_decision",
+        "tie_break": "zero_bit",
+        "syndrome_projection": "none",
+    },
+    "stabilizer_coset_aggregate": {
+        "kind": "semiring_aggregate_over_stabilizer_equivalence_class",
+        "class_tie_break": "lowest_canonical_coset_key",
+        "representative_within_class": "lowest_hamming_weight_then_integer",
+    },
+}
+
+digest = F2.canonical_digest
+syndrome = F2.syndrome
+i2b = F2.i2b
+
+
+def keys(d: dict[str, Any], expected: set[str], where: str) -> None:
+    if set(d) != expected:
+        raise ValueError(
+            f"{where} key mismatch: missing={sorted(expected-set(d))}, "
+            f"extra={sorted(set(d)-expected)}"
+        )
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_registry(path: Path) -> dict[str, Any]:
+    data = load_json(path)
+    keys(data, {"registry_version", "experiments"}, "registry")
+    if data["registry_version"] != "0.1.0" or not isinstance(data["experiments"], list):
+        raise ValueError("invalid TCM-QDEC registry")
+    matches = [x for x in data["experiments"] if x.get("experiment_id") == "TCM-QDEC-001"]
+    if len(matches) != 1:
+        raise ValueError("TCM-QDEC-001 must appear exactly once")
+    e = matches[0]
+    keys(
+        e,
+        {
+            "experiment_id", "programme", "status", "predecessor", "state_space",
+            "semirings", "quotient_treatments", "claim_boundary",
+        },
+        "experiment",
+    )
+    if e["programme"] != "QTR" or e["status"] != "candidate_executable_not_promoted":
+        raise ValueError("TCM-QDEC experiment identity/status changed")
+    expected_predecessor = {
+        "fixture_id": "QLDPC-FIXTURE-002",
+        "evidence_path": "evidence/QLDPC-FIXTURE-002-report.json",
+        "evidence_payload_sha256": FIXTURE_002_PAYLOAD,
+        "corpus_sha256": FIXTURE_002_CORPUS,
+        "scientific_merge_commit": FIXTURE_002_SCIENTIFIC_MERGE,
+        "promotion_merge_commit": FIXTURE_002_PROMOTION_MERGE,
+        "promotion_record_path": "reviews/QTR-QLDPC-REVIEW-002/promotion-record.json",
+    }
+    expected_state = {
+        "sector_model": "code_capacity_single_css_sector",
+        "corpus_kind": "fixture_002_frozen_hamming_weight_0_through_4",
+        "corpus_size": 4048,
+        "corpus_sha256": FIXTURE_002_CORPUS,
+        "full_physical_error_states": 262144,
+        "reachable_syndromes": 128,
+        "states_per_syndrome": 2048,
+        "stabilizer_span_size": 128,
+        "logical_cosets_per_syndrome": 16,
+    }
+    for name, observed, expected in (
+        ("predecessor", e["predecessor"], expected_predecessor),
+        ("state_space", e["state_space"], expected_state),
+        ("semirings", e["semirings"], SEMIRINGS),
+        ("quotient_treatments", e["quotient_treatments"], TREATMENTS),
+        ("claim_boundary", e["claim_boundary"], CLAIM_BOUNDARY),
+    ):
+        if observed != expected:
+            raise ValueError(f"{name} unexpectedly changed")
+    return e
+
+
+def validate_predecessors(
+    fixture1: dict[str, Any], fixture2: dict[str, Any], promotion2: dict[str, Any]
+) -> tuple[list[int], set[int], int]:
+    if fixture1.get("payload_sha256") != FIXTURE_001_PAYLOAD:
+        raise ValueError("Fixture 001 payload mismatch")
+    _, rows, stabilizers, n = F2.validate_predecessor(fixture1)
+
+    if fixture2.get("fixture_id") != "QLDPC-FIXTURE-002":
+        raise ValueError("Fixture 002 identity mismatch")
+    if fixture2.get("payload_sha256") != FIXTURE_002_PAYLOAD:
+        raise ValueError("Fixture 002 payload mismatch")
+    unsigned2 = dict(fixture2)
+    unsigned2.pop("payload_sha256", None)
+    if digest(unsigned2) != FIXTURE_002_PAYLOAD:
+        raise ValueError("Fixture 002 payload does not self-verify")
+    corpus = fixture2.get("corpus", {})
+    if (
+        corpus.get("corpus_sha256") != FIXTURE_002_CORPUS
+        or corpus.get("actual_error_count") != 4048
+        or corpus.get("max_weight") != 4
+        or corpus.get("sector_model") != "code_capacity_single_css_sector"
+    ):
+        raise ValueError("Fixture 002 frozen corpus changed")
+    boundary = fixture2.get("claim_boundary", {})
+    if boundary.get("systems_benchmark_only") is not True:
+        raise ValueError("Fixture 002 authority missing")
+    for name in (
+        "tcm_qdec_authorized", "qldpc_forge_authorized",
+        "autonomous_search_authorized", "circuit_level_noise_claim",
+        "hardware_validation_claim", "threshold_claim",
+    ):
+        if boundary.get(name) is not False:
+            raise ValueError(f"Fixture 002 forbidden inherited authority enabled: {name}")
+    exact = fixture2.get("benchmark_results", {}).get("exact_coset_lookup", {})
+    greedy = fixture2.get("benchmark_results", {}).get("greedy_syndrome_descent", {})
+    if exact.get("table_sha256") != EXACT_TABLE_SHA or exact.get("success_total") != 240:
+        raise ValueError("Fixture 002 exact baseline changed")
+    if greedy.get("success_total") != 125:
+        raise ValueError("Fixture 002 greedy baseline changed")
+
+    if promotion2.get("record_id") != "QTR-QLDPC-REVIEW-002-PROMOTION":
+        raise ValueError("Fixture 002 promotion record identity mismatch")
+    if promotion2.get("status") != "referee_promoted_bounded":
+        raise ValueError("Fixture 002 is not bounded promoted")
+    if promotion2.get("scientific_merge_commit") != FIXTURE_002_SCIENTIFIC_MERGE:
+        raise ValueError("Fixture 002 scientific merge mismatch")
+    snap = promotion2.get("reviewed_snapshot", {})
+    if (
+        snap.get("evidence_payload_sha256") != FIXTURE_002_PAYLOAD
+        or snap.get("corpus_sha256") != FIXTURE_002_CORPUS
+        or snap.get("snapshot_preserved_byte_for_byte") is not True
+    ):
+        raise ValueError("Fixture 002 reviewed snapshot mismatch")
+    return rows, stabilizers, n
+
+
+def build_coset_keys(stabilizers: set[int], n: int) -> list[int]:
+    out = [-1] * (1 << n)
+    for seed in range(1 << n):
+        if out[seed] != -1:
+            continue
+        orbit = [seed ^ s for s in stabilizers]
+        key = min(orbit)
+        for state in orbit:
+            out[state] = key
+    if any(x < 0 for x in out):
+        raise AssertionError("incomplete stabilizer-coset partition")
+    return out
+
+
+def winning_keys(stats: dict[int, dict[str, int]], algebra: str) -> list[int]:
+    if algebra == "sum_product_bsc_p_0_1":
+        best = max(x["mass9"] for x in stats.values())
+        return sorted(k for k, x in stats.items() if x["mass9"] == best)
+    if algebra == "soft_tropical_base_2":
+        best = max(x["mass2"] for x in stats.values())
+        return sorted(k for k, x in stats.items() if x["mass2"] == best)
+    best = min(x["min_weight"] for x in stats.values())
+    return sorted(k for k, x in stats.items() if x["min_weight"] == best)
+
+
+def infer_tables(
+    rows: list[int], stabilizers: set[int], n: int
+) -> tuple[
+    dict[str, dict[str, dict[int, int]]],
+    dict[str, Any],
+    dict[str, dict[int, list[int]]],
+    list[int],
+]:
+    by_syndrome: dict[int, list[int]] = {}
+    for state in range(1 << n):
+        by_syndrome.setdefault(syndrome(state, rows), []).append(state)
+    if len(by_syndrome) != 128 or set(map(len, by_syndrome.values())) != {2048}:
+        raise AssertionError("unexpected syndrome state-space geometry")
+
+    coset_keys = build_coset_keys(stabilizers, n)
+    tables = {t: {a: {} for a in SEMIRINGS} for t in TREATMENTS}
+    quotient_ties = {a: {} for a in SEMIRINGS}
+    diagnostics = {
+        t: {
+            a: {
+                "unique_syndrome_decisions": 0,
+                "syndrome_valid_decisions": 0,
+                "syndrome_invalid_decisions": 0,
+                "decision_tie_syndromes": 0,
+                "decision_table_sha256": None,
+            }
+            for a in SEMIRINGS
+        }
+        for t in TREATMENTS
+    }
+
+    for syn in sorted(by_syndrome):
+        states = by_syndrome[syn]
+        marginal9 = [[0, 0] for _ in range(n)]
+        marginal2 = [[0, 0] for _ in range(n)]
+        marginal_min = [[n + 1, n + 1] for _ in range(n)]
+        classes: dict[int, dict[str, int]] = {}
+
+        for state in states:
+            w = state.bit_count()
+            m9 = 9 ** (n - w)
+            m2 = 2 ** (n - w)
+            for q in range(n):
+                bit = (state >> q) & 1
+                marginal9[q][bit] += m9
+                marginal2[q][bit] += m2
+                marginal_min[q][bit] = min(marginal_min[q][bit], w)
+
+            key = coset_keys[state]
+            item = classes.setdefault(
+                key,
+                {"mass9": 0, "mass2": 0, "min_weight": n + 1,
+                 "representative": state, "count": 0},
+            )
+            item["mass9"] += m9
+            item["mass2"] += m2
+            item["count"] += 1
+            if (w, state) < (item["min_weight"], item["representative"]):
+                item["min_weight"] = w
+                item["representative"] = state
+
+        if len(classes) != 16 or set(x["count"] for x in classes.values()) != {128}:
+            raise AssertionError("unexpected logical-coset geometry")
+
+        for algebra in SEMIRINGS:
+            rep = 0
+            bit_ties = 0
+            for q in range(n):
+                if algebra == "sum_product_bsc_p_0_1":
+                    zero, one = marginal9[q]
+                    bit = int(one > zero)
+                elif algebra == "soft_tropical_base_2":
+                    zero, one = marginal2[q]
+                    bit = int(one > zero)
+                else:
+                    zero, one = marginal_min[q]
+                    bit = int(one < zero)
+                bit_ties += int(one == zero)
+                if bit:
+                    rep |= 1 << q
+            tables["representative_naive_marginals"][algebra][syn] = rep
+            rd = diagnostics["representative_naive_marginals"][algebra]
+            rd["unique_syndrome_decisions"] += 1
+            valid = syndrome(rep, rows) == syn
+            rd["syndrome_valid_decisions"] += int(valid)
+            rd["syndrome_invalid_decisions"] += int(not valid)
+            rd["decision_tie_syndromes"] += int(bit_ties > 0)
+
+            tied = winning_keys(classes, algebra)
+            quotient_ties[algebra][syn] = tied
+            correction = classes[tied[0]]["representative"]
+            tables["stabilizer_coset_aggregate"][algebra][syn] = correction
+            qd = diagnostics["stabilizer_coset_aggregate"][algebra]
+            qd["unique_syndrome_decisions"] += 1
+            valid = syndrome(correction, rows) == syn
+            qd["syndrome_valid_decisions"] += int(valid)
+            qd["syndrome_invalid_decisions"] += int(not valid)
+            qd["decision_tie_syndromes"] += int(len(tied) > 1)
+
+    for treatment in TREATMENTS:
+        for algebra in SEMIRINGS:
+            records = [
+                {"syndrome": i2b(s, len(rows)), "correction": i2b(c, n)}
+                for s, c in sorted(tables[treatment][algebra].items())
+            ]
+            diagnostics[treatment][algebra]["decision_table_sha256"] = digest(records)
+    return tables, diagnostics, quotient_ties, coset_keys
+
+
+def classify(
+    corpus: list[int], rows: list[int], stabilizers: set[int], table: dict[int, int]
+) -> tuple[dict[str, Any], list[bool]]:
+    shell: dict[str, dict[str, int]] = {}
+    failures = {"nonzero_residual_syndrome": 0,
+                "zero_syndrome_wrong_logical_coset": 0}
+    outcomes: list[bool] = []
+    for error in corpus:
+        syn = syndrome(error, rows)
+        correction = table[syn]
+        residual = error ^ correction
+        residual_syndrome = syndrome(residual, rows)
+        ok = residual_syndrome == 0 and residual in stabilizers
+        outcomes.append(ok)
+        bucket = shell.setdefault(
+            str(error.bit_count()), {"success": 0, "failure": 0, "total": 0}
+        )
+        bucket["total"] += 1
+        bucket["success" if ok else "failure"] += 1
+        if not ok:
+            failures[
+                "nonzero_residual_syndrome"
+                if residual_syndrome
+                else "zero_syndrome_wrong_logical_coset"
+            ] += 1
+    total = sum(outcomes)
+    return {
+        "success_total": total,
+        "failure_total": len(outcomes) - total,
+        "success_counts_by_error_weight": shell,
+        "failure_modes": failures,
+    }, outcomes
+
+
+def delta(first: list[bool], second: list[bool]) -> dict[str, int]:
+    return {
+        "repaired_by_second": sum((not a) and b for a, b in zip(first, second)),
+        "broken_by_second": sum(a and (not b) for a, b in zip(first, second)),
+        "same_outcome": sum(a == b for a, b in zip(first, second)),
+    }
+
+
+def comparison_witnesses(
+    corpus: list[int], rows: list[int], first: dict[int, int], second: dict[int, int],
+    first_outcomes: list[bool], second_outcomes: list[bool], limit: int = 8,
+) -> dict[str, list[dict[str, Any]]]:
+    repaired: list[dict[str, Any]] = []
+    broken: list[dict[str, Any]] = []
+    for error, a_ok, b_ok in zip(corpus, first_outcomes, second_outcomes):
+        if a_ok == b_ok:
+            continue
+        syn = syndrome(error, rows)
+        record = {
+            "error_weight": error.bit_count(),
+            "error": i2b(error, 18),
+            "syndrome": i2b(syn, len(rows)),
+            "first_correction": i2b(first[syn], 18),
+            "second_correction": i2b(second[syn], 18),
+        }
+        if not a_ok and b_ok and len(repaired) < limit:
+            repaired.append(record)
+        elif a_ok and not b_ok and len(broken) < limit:
+            broken.append(record)
+    return {"repaired_witnesses": repaired, "broken_witnesses": broken}
+
+
+def tie_sensitivity(
+    corpus: list[int], rows: list[int], coset_keys: list[int],
+    quotient_ties: dict[str, dict[int, list[int]]],
+) -> dict[str, Any]:
+    counts: dict[int, dict[int, int]] = {}
+    for error in corpus:
+        syn = syndrome(error, rows)
+        key = coset_keys[error]
+        counts.setdefault(syn, {})
+        counts[syn][key] = counts[syn].get(key, 0) + 1
+
+    out: dict[str, Any] = {}
+    for algebra in SEMIRINGS:
+        default = lower = upper = 0
+        hist: dict[str, int] = {}
+        for syn, tied in quotient_ties[algebra].items():
+            hist[str(len(tied))] = hist.get(str(len(tied)), 0) + 1
+            values = [counts.get(syn, {}).get(key, 0) for key in tied]
+            default += counts.get(syn, {}).get(tied[0], 0)
+            lower += min(values)
+            upper += max(values)
+        out[algebra] = {
+            "winning_class_count_histogram": hist,
+            "default_lowest_key_success_count": default,
+            "frozen_corpus_success_count_envelope_over_winning_class_ties":
+                {"min": lower, "max": upper},
+            "success_count_invariant_under_winning_class_tie_break": lower == upper,
+        }
+    return out
+
+
+def evaluate(
+    experiment: dict[str, Any], fixture1: dict[str, Any],
+    fixture2: dict[str, Any], promotion2: dict[str, Any],
+) -> dict[str, Any]:
+    rows, stabilizers, n = validate_predecessors(fixture1, fixture2, promotion2)
+    corpus = F2.make_corpus(n, 4)
+    corpus_records = [{"weight": e.bit_count(), "error": i2b(e, n)} for e in corpus]
+    corpus_sha = digest(corpus_records)
+    if len(corpus) != 4048 or corpus_sha != FIXTURE_002_CORPUS:
+        raise AssertionError("frozen corpus does not replay Fixture 002")
+
+    tables, diagnostics, quotient_ties, coset_keys = infer_tables(
+        rows, stabilizers, n
+    )
+
+    exact_table, considered = F2.min_table(rows, n)
+    exact_records = [
+        {"syndrome": i2b(s, len(rows)), "correction": i2b(e, n),
+         "weight": e.bit_count()}
+        for s, e in sorted(exact_table.items())
+    ]
+    if digest(exact_records) != EXACT_TABLE_SHA or considered != 988:
+        raise AssertionError("Fixture 002 exact lookup identity changed")
+    columns = [syndrome(1 << q, rows) for q in range(n)]
+    greedy_table = {
+        s: F2.greedy(s, columns, n)[0]
+        for s in exact_table
+    }
+    exact_result, exact_outcomes = classify(corpus, rows, stabilizers, exact_table)
+    greedy_result, greedy_outcomes = classify(corpus, rows, stabilizers, greedy_table)
+    if exact_result["success_total"] != 240 or greedy_result["success_total"] != 125:
+        raise AssertionError("Fixture 002 baseline outcomes changed")
+
+    matrix: dict[str, dict[str, Any]] = {}
+    outcomes: dict[tuple[str, str], list[bool]] = {}
+    for treatment in TREATMENTS:
+        matrix[treatment] = {}
+        for algebra in SEMIRINGS:
+            result, out = classify(corpus, rows, stabilizers, tables[treatment][algebra])
+            outcomes[(treatment, algebra)] = out
+            matrix[treatment][algebra] = {
+                **result,
+                "decision_diagnostics": diagnostics[treatment][algebra],
+            }
+
+    comparisons: dict[str, Any] = {}
+    for algebra in SEMIRINGS:
+        naive = outcomes[("representative_naive_marginals", algebra)]
+        quotient = outcomes[("stabilizer_coset_aggregate", algebra)]
+        comparisons[algebra] = {
+            "quotient_minus_representative_success_count": sum(quotient) - sum(naive),
+            "quotient_vs_representative": {
+                **delta(naive, quotient),
+                **comparison_witnesses(
+                    corpus, rows,
+                    tables["representative_naive_marginals"][algebra],
+                    tables["stabilizer_coset_aggregate"][algebra],
+                    naive, quotient,
+                ),
+            },
+            "quotient_minus_fixture_002_exact_success_count":
+                sum(quotient) - sum(exact_outcomes),
+            "quotient_vs_fixture_002_exact": delta(exact_outcomes, quotient),
+            "quotient_minus_fixture_002_greedy_success_count":
+                sum(quotient) - sum(greedy_outcomes),
+            "quotient_vs_fixture_002_greedy": delta(greedy_outcomes, quotient),
+        }
+
+    report: dict[str, Any] = {
+        "experiment_id": "TCM-QDEC-001",
+        "evaluator_version": EVALUATOR_VERSION,
+        "status": "candidate_executable_not_promoted",
+        "predecessor": experiment["predecessor"],
+        "claim_boundary": experiment["claim_boundary"],
+        "state_space": {
+            **experiment["state_space"],
+            "replayed_corpus_sha256": corpus_sha,
+            "full_state_enumeration_count": 1 << n,
+        },
+        "semirings": experiment["semirings"],
+        "quotient_treatments": experiment["quotient_treatments"],
+        "fixture_002_baselines": {
+            "exact_coset_lookup": exact_result,
+            "greedy_syndrome_descent": greedy_result,
+        },
+        "inference_matrix": matrix,
+        "tie_sensitivity": tie_sensitivity(corpus, rows, coset_keys, quotient_ties),
+        "comparisons": comparisons,
+    }
+    report["payload_sha256"] = digest(report)
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--registry", default=str(ROOT / "registry" / "tcm-qdec.json"))
+    parser.add_argument("--fixture-001",
+                        default=str(ROOT / "evidence" / "QLDPC-FIXTURE-001-report.json"))
+    parser.add_argument("--fixture-002",
+                        default=str(ROOT / "evidence" / "QLDPC-FIXTURE-002-report.json"))
+    parser.add_argument(
+        "--fixture-002-promotion",
+        default=str(ROOT / "reviews" / "QTR-QLDPC-REVIEW-002" / "promotion-record.json"),
+    )
+    parser.add_argument("--output")
+    args = parser.parse_args()
+    report = evaluate(
+        load_registry(Path(args.registry)),
+        load_json(Path(args.fixture_001)),
+        load_json(Path(args.fixture_002)),
+        load_json(Path(args.fixture_002_promotion)),
+    )
+    text = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reference/tcm_qdec_001.py
+++ b/reference/tcm_qdec_001.py
@@ -337,7 +337,7 @@ def infer_tables(
 def classify(
     corpus: list[int], rows: list[int], stabilizers: set[int], table: dict[int, int]
 ) -> tuple[dict[str, Any], list[bool]]:
-    shell: dict[str, dict[str, int]] = {}
+    shell: dict[str, int] = {}
     failures = {"nonzero_residual_syndrome": 0,
                 "zero_syndrome_wrong_logical_coset": 0}
     outcomes: list[bool] = []
@@ -348,11 +348,8 @@ def classify(
         residual_syndrome = syndrome(residual, rows)
         ok = residual_syndrome == 0 and residual in stabilizers
         outcomes.append(ok)
-        bucket = shell.setdefault(
-            str(error.bit_count()), {"success": 0, "failure": 0, "total": 0}
-        )
-        bucket["total"] += 1
-        bucket["success" if ok else "failure"] += 1
+        w = str(error.bit_count())
+        shell[w] = shell.get(w, 0) + int(ok)
         if not ok:
             failures[
                 "nonzero_residual_syndrome"
@@ -363,7 +360,7 @@ def classify(
     return {
         "success_total": total,
         "failure_total": len(outcomes) - total,
-        "success_counts_by_error_weight": shell,
+        "success_by_error_weight": shell,
         "failure_modes": failures,
     }, outcomes
 
@@ -378,7 +375,7 @@ def delta(first: list[bool], second: list[bool]) -> dict[str, int]:
 
 def comparison_witnesses(
     corpus: list[int], rows: list[int], first: dict[int, int], second: dict[int, int],
-    first_outcomes: list[bool], second_outcomes: list[bool], limit: int = 8,
+    first_outcomes: list[bool], second_outcomes: list[bool], limit: int = 4,
 ) -> dict[str, list[dict[str, Any]]]:
     repaired: list[dict[str, Any]] = []
     broken: list[dict[str, Any]] = []

--- a/registry/tcm-qdec.json
+++ b/registry/tcm-qdec.json
@@ -1,0 +1,79 @@
+{
+  "experiments": [
+    {
+      "claim_boundary": {
+        "autonomous_search_authorized": false,
+        "bp_osd_performance_claim": false,
+        "circuit_level_noise_claim": false,
+        "decoder_performance_superiority_claim": false,
+        "exact_state_space_enumeration": true,
+        "finite_semiring_comparison_only": true,
+        "frozen_fixture_002_corpus_only": true,
+        "general_qldpc_decoder_claim": false,
+        "hardware_validation_claim": false,
+        "learned_decoder_authorized": false,
+        "portable_latency_or_memory_claim": false,
+        "qldpc_forge_authorized": false,
+        "scalable_tensor_contraction_claim": false,
+        "tcm_qdec_002_authorized": false,
+        "threshold_claim": false
+      },
+      "experiment_id": "TCM-QDEC-001",
+      "predecessor": {
+        "corpus_sha256": "260b1a43cf1d777f28c475918e91a5f7cefc5d28a2bfb556338f7e30058f58a8",
+        "evidence_path": "evidence/QLDPC-FIXTURE-002-report.json",
+        "evidence_payload_sha256": "d98c5d73f7fdf9259a35be60580dc9b6c32c5e4483cd765ed0dcba594b9299e5",
+        "fixture_id": "QLDPC-FIXTURE-002",
+        "promotion_merge_commit": "074612e39e1232d1644edc487914ca571189f409",
+        "promotion_record_path": "reviews/QTR-QLDPC-REVIEW-002/promotion-record.json",
+        "scientific_merge_commit": "51c31bde2e0630314d3d48dceb9b92969c37c228"
+      },
+      "programme": "QTR",
+      "quotient_treatments": {
+        "representative_naive_marginals": {
+          "kind": "coordinatewise_semiring_marginal_hard_decision",
+          "syndrome_projection": "none",
+          "tie_break": "zero_bit"
+        },
+        "stabilizer_coset_aggregate": {
+          "class_tie_break": "lowest_canonical_coset_key",
+          "kind": "semiring_aggregate_over_stabilizer_equivalence_class",
+          "representative_within_class": "lowest_hamming_weight_then_integer"
+        }
+      },
+      "semirings": {
+        "min_plus_hamming": {
+          "exact_state_weight": "hamming_weight",
+          "interpretation": "minimum Hamming-weight tropical score",
+          "kind": "min_plus",
+          "score_direction": "minimize"
+        },
+        "soft_tropical_base_2": {
+          "exact_state_weight": "2**(n-hamming_weight)",
+          "interpretation": "exact partition score equivalent in ranking to beta=ln(2) soft-min",
+          "kind": "soft_tropical",
+          "score_direction": "maximize"
+        },
+        "sum_product_bsc_p_0_1": {
+          "exact_state_weight": "9**(n-hamming_weight)",
+          "interpretation": "exact numerator proportional to BSC p=0.1 likelihood",
+          "kind": "sum_product",
+          "score_direction": "maximize"
+        }
+      },
+      "state_space": {
+        "corpus_kind": "fixture_002_frozen_hamming_weight_0_through_4",
+        "corpus_sha256": "260b1a43cf1d777f28c475918e91a5f7cefc5d28a2bfb556338f7e30058f58a8",
+        "corpus_size": 4048,
+        "full_physical_error_states": 262144,
+        "logical_cosets_per_syndrome": 16,
+        "reachable_syndromes": 128,
+        "sector_model": "code_capacity_single_css_sector",
+        "stabilizer_span_size": 128,
+        "states_per_syndrome": 2048
+      },
+      "status": "candidate_executable_not_promoted"
+    }
+  ],
+  "registry_version": "0.1.0"
+}

--- a/tests/test_tcm_qdec_001.py
+++ b/tests/test_tcm_qdec_001.py
@@ -1,0 +1,205 @@
+import copy
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "reference" / "tcm_qdec_001.py"
+SPEC = importlib.util.spec_from_file_location("tcm_qdec_001", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+EXPECTED_PAYLOAD = "1b19addcda5e04cf78a834b2162fe0873ed5eb15f3330995d8354906944b7122"
+
+
+class TCMQDEC001Tests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.registry_path = ROOT / "registry" / "tcm-qdec.json"
+        cls.fixture1_path = ROOT / "evidence" / "QLDPC-FIXTURE-001-report.json"
+        cls.fixture2_path = ROOT / "evidence" / "QLDPC-FIXTURE-002-report.json"
+        cls.promotion2_path = (
+            ROOT / "reviews" / "QTR-QLDPC-REVIEW-002" / "promotion-record.json"
+        )
+        cls.experiment = MODULE.load_registry(cls.registry_path)
+        cls.fixture1 = MODULE.load_json(cls.fixture1_path)
+        cls.fixture2 = MODULE.load_json(cls.fixture2_path)
+        cls.promotion2 = MODULE.load_json(cls.promotion2_path)
+        cls.report = MODULE.evaluate(
+            cls.experiment, cls.fixture1, cls.fixture2, cls.promotion2
+        )
+
+    def test_committed_evidence_exactly_replays(self):
+        expected = MODULE.load_json(ROOT / "evidence" / "TCM-QDEC-001-report.json")
+        self.assertEqual(self.report, expected)
+        self.assertEqual(self.report["payload_sha256"], EXPECTED_PAYLOAD)
+
+    def test_full_state_space_geometry_and_frozen_corpus(self):
+        state = self.report["state_space"]
+        self.assertEqual(state["full_state_enumeration_count"], 262144)
+        self.assertEqual(state["reachable_syndromes"], 128)
+        self.assertEqual(state["states_per_syndrome"], 2048)
+        self.assertEqual(state["stabilizer_span_size"], 128)
+        self.assertEqual(state["logical_cosets_per_syndrome"], 16)
+        self.assertEqual(state["corpus_size"], 4048)
+        self.assertEqual(
+            state["replayed_corpus_sha256"],
+            "260b1a43cf1d777f28c475918e91a5f7cefc5d28a2bfb556338f7e30058f58a8",
+        )
+
+    def test_exact_six_cell_success_matrix(self):
+        matrix = self.report["inference_matrix"]
+        naive = matrix["representative_naive_marginals"]
+        quotient = matrix["stabilizer_coset_aggregate"]
+        self.assertEqual(naive["sum_product_bsc_p_0_1"]["success_total"], 37)
+        self.assertEqual(naive["soft_tropical_base_2"]["success_total"], 1)
+        self.assertEqual(naive["min_plus_hamming"]["success_total"], 37)
+        self.assertEqual(quotient["sum_product_bsc_p_0_1"]["success_total"], 263)
+        self.assertEqual(quotient["soft_tropical_base_2"]["success_total"], 262)
+        self.assertEqual(quotient["min_plus_hamming"]["success_total"], 226)
+
+    def test_representative_outputs_preserve_syndrome_failures_as_evidence(self):
+        matrix = self.report["inference_matrix"]["representative_naive_marginals"]
+        self.assertEqual(
+            matrix["sum_product_bsc_p_0_1"]["decision_diagnostics"][
+                "syndrome_invalid_decisions"
+            ],
+            91,
+        )
+        self.assertEqual(
+            matrix["soft_tropical_base_2"]["decision_diagnostics"][
+                "syndrome_invalid_decisions"
+            ],
+            127,
+        )
+        self.assertEqual(
+            matrix["min_plus_hamming"]["decision_diagnostics"][
+                "syndrome_invalid_decisions"
+            ],
+            91,
+        )
+
+    def test_quotient_outputs_realize_every_input_syndrome(self):
+        quotient = self.report["inference_matrix"]["stabilizer_coset_aggregate"]
+        for algebra in MODULE.SEMIRINGS:
+            diagnostics = quotient[algebra]["decision_diagnostics"]
+            self.assertEqual(diagnostics["syndrome_valid_decisions"], 128)
+            self.assertEqual(diagnostics["syndrome_invalid_decisions"], 0)
+
+    def test_quotient_repairs_matched_representative_without_hidden_breaks(self):
+        comparisons = self.report["comparisons"]
+        expected_repairs = {
+            "sum_product_bsc_p_0_1": 226,
+            "soft_tropical_base_2": 261,
+            "min_plus_hamming": 189,
+        }
+        for algebra, repairs in expected_repairs.items():
+            delta = comparisons[algebra]["quotient_vs_representative"]
+            self.assertEqual(delta["repaired_by_second"], repairs)
+            self.assertEqual(delta["broken_by_second"], 0)
+            self.assertTrue(delta["repaired_witnesses"])
+
+    def test_fixture_002_baselines_replay_and_net_gain_is_not_monotone_superiority(self):
+        baselines = self.report["fixture_002_baselines"]
+        self.assertEqual(baselines["exact_coset_lookup"]["success_total"], 240)
+        self.assertEqual(baselines["greedy_syndrome_descent"]["success_total"], 125)
+        sum_product = self.report["comparisons"]["sum_product_bsc_p_0_1"]
+        self.assertEqual(sum_product["quotient_minus_fixture_002_exact_success_count"], 23)
+        exact_delta = sum_product["quotient_vs_fixture_002_exact"]
+        self.assertEqual(exact_delta["repaired_by_second"], 131)
+        self.assertEqual(exact_delta["broken_by_second"], 108)
+
+    def test_tie_sensitivity_is_retained(self):
+        ties = self.report["tie_sensitivity"]
+        self.assertEqual(
+            ties["sum_product_bsc_p_0_1"][
+                "frozen_corpus_success_count_envelope_over_winning_class_ties"
+            ],
+            {"min": 263, "max": 263},
+        )
+        self.assertTrue(
+            ties["sum_product_bsc_p_0_1"][
+                "success_count_invariant_under_winning_class_tie_break"
+            ]
+        )
+        self.assertEqual(
+            ties["soft_tropical_base_2"][
+                "frozen_corpus_success_count_envelope_over_winning_class_ties"
+            ],
+            {"min": 262, "max": 262},
+        )
+        self.assertTrue(
+            ties["soft_tropical_base_2"][
+                "success_count_invariant_under_winning_class_tie_break"
+            ]
+        )
+        self.assertEqual(
+            ties["min_plus_hamming"][
+                "frozen_corpus_success_count_envelope_over_winning_class_ties"
+            ],
+            {"min": 218, "max": 263},
+        )
+        self.assertEqual(ties["min_plus_hamming"]["default_lowest_key_success_count"], 226)
+        self.assertFalse(
+            ties["min_plus_hamming"][
+                "success_count_invariant_under_winning_class_tie_break"
+            ]
+        )
+
+    def test_registry_semiring_drift_fails_closed(self):
+        registry = MODULE.load_json(self.registry_path)
+        registry["experiments"][0]["semirings"]["soft_tropical_base_2"][
+            "exact_state_weight"
+        ] = "3**(n-hamming_weight)"
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "registry.json"
+            path.write_text(json.dumps(registry), encoding="utf-8")
+            with self.assertRaises(ValueError):
+                MODULE.load_registry(path)
+
+    def test_registry_downstream_authority_tamper_fails_closed(self):
+        registry = MODULE.load_json(self.registry_path)
+        registry["experiments"][0]["claim_boundary"]["qldpc_forge_authorized"] = True
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "registry.json"
+            path.write_text(json.dumps(registry), encoding="utf-8")
+            with self.assertRaises(ValueError):
+                MODULE.load_registry(path)
+
+    def test_fixture_002_payload_tamper_fails_closed(self):
+        fixture2 = copy.deepcopy(self.fixture2)
+        fixture2["payload_sha256"] = "0" * 64
+        with self.assertRaises(ValueError):
+            MODULE.validate_predecessors(self.fixture1, fixture2, self.promotion2)
+
+    def test_fixture_002_promotion_tamper_fails_closed(self):
+        promotion = copy.deepcopy(self.promotion2)
+        promotion["status"] = "candidate_executable_not_promoted"
+        with self.assertRaises(ValueError):
+            MODULE.validate_predecessors(self.fixture1, self.fixture2, promotion)
+
+    def test_downstream_and_performance_authority_remain_closed(self):
+        boundary = self.report["claim_boundary"]
+        self.assertTrue(boundary["finite_semiring_comparison_only"])
+        for key in (
+            "scalable_tensor_contraction_claim",
+            "general_qldpc_decoder_claim",
+            "decoder_performance_superiority_claim",
+            "bp_osd_performance_claim",
+            "circuit_level_noise_claim",
+            "hardware_validation_claim",
+            "threshold_claim",
+            "portable_latency_or_memory_claim",
+            "learned_decoder_authorized",
+            "tcm_qdec_002_authorized",
+            "qldpc_forge_authorized",
+            "autonomous_search_authorized",
+        ):
+            self.assertFalse(boundary[key], key)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/work-packages/QTR-TCM-QDEC-001.md
+++ b/work-packages/QTR-TCM-QDEC-001.md
@@ -1,0 +1,251 @@
+# QTR-TCM-QDEC-001 — Degeneracy-aware finite semiring inference audit
+
+Status: `candidate_executable_not_promoted`
+
+Programme: `GCL Quantum Technologies Research (QTR)`
+
+Experiment identifier: `TCM-QDEC-001`
+
+Tracking issue: `#37`
+
+Predecessor: `QLDPC-FIXTURE-002`
+
+## 1. Purpose
+
+This work package opens the first bounded `TCM-QDEC` experiment above the two promoted qLDPC fixtures.
+
+Its single question is:
+
+> When the protected code, syndrome, frozen error corpus, and correctness oracle are held fixed, does explicit aggregation over stabilizer-equivalent error classes change the decisions produced by otherwise matched finite semiring inference?
+
+The experiment is an exact finite semantic oracle. It is not a scalable decoder implementation, tensor-network benchmark, threshold study, or hardware experiment.
+
+A favorable result is not required for admission. Tie sensitivity, regressions, and negative evidence are first-class outputs.
+
+## 2. Protected predecessor
+
+The experiment consumes the immutable Fixture 002 evidence and promotion overlay rather than redefining the benchmark substrate.
+
+Bound identities are:
+
+- Fixture 002 evidence payload: `d98c5d73f7fdf9259a35be60580dc9b6c32c5e4483cd765ed0dcba594b9299e5`;
+- frozen corpus SHA-256: `260b1a43cf1d777f28c475918e91a5f7cefc5d28a2bfb556338f7e30058f58a8`;
+- Fixture 002 scientific merge: `51c31bde2e0630314d3d48dceb9b92969c37c228`;
+- Fixture 002 promotion merge: `074612e39e1232d1644edc487914ca571189f409`;
+- Fixture 001 evidence payload: `6c2095f48762178bf0fe5c2b5fce8299261733912a1cccc7884d11f344718427`;
+- exact coset-leader table SHA-256: `96ce94c378b7b1fc5fe032fbd253aa932c1ca8abcb17b3d3c89b3ecda601da29`.
+
+The promoted predecessors remain unchanged by this package.
+
+## 3. Exact finite state space
+
+For the protected one-sector `[[18,4,4]]` instance, the evaluator enumerates all
+
+\[
+2^{18}=262144
+\]
+
+physical error representatives.
+
+The exact finite geometry is:
+
+- `128` reachable syndromes;
+- `2048` physical error representatives for each syndrome;
+- stabilizer span size `128`;
+- `16` stabilizer-equivalence logical classes for each syndrome.
+
+Scoring remains restricted to the Fixture 002 frozen corpus of all 18-bit errors of Hamming weight `0..4`, totalling `4048` cases.
+
+No sampling or random seed is used.
+
+## 4. Controlled axis A — terminal treatment
+
+Only the terminal treatment of the syndrome-compatible error space is varied.
+
+### 4.1 Representative-naive marginals
+
+`representative_naive_marginals` computes exact coordinatewise semiring marginals over physical error representatives compatible with the input syndrome. Each coordinate is hard-decoded independently. Bit ties choose zero.
+
+No syndrome repair or projection is applied after the coordinatewise decision. If the resulting physical representative does not realize the input syndrome, that failure is retained explicitly.
+
+This construction is intentionally a diagnostic representative-space baseline. It is not claimed to be a competitive practical decoder.
+
+### 4.2 Stabilizer-coset aggregation
+
+`stabilizer_coset_aggregate` first quotients syndrome-compatible error representatives by the certified stabilizer span. The semiring score is aggregated over each of the `16` logical classes.
+
+The winning class is selected by the declared semiring reduction. If several classes tie, the default rule chooses the lowest canonical coset key. The emitted correction is the lowest-Hamming-weight representative in the selected class, with integer order as the final tie break.
+
+Because the emitted representative belongs to the selected syndrome-compatible class, this treatment realizes every input syndrome by construction.
+
+## 5. Controlled axis B — exact semiring reduction
+
+Three reductions are compared. All ranking arithmetic is exact integer arithmetic.
+
+### 5.1 Sum-product
+
+`sum_product_bsc_p_0_1` assigns an error of weight `w` the integer score
+
+\[
+9^{18-w},
+\]
+
+which is proportional to the likelihood numerator for an independent binary symmetric channel with `p=0.1`. Scores are summed within the relevant marginal or quotient class and maximized.
+
+### 5.2 Soft tropical
+
+`soft_tropical_base_2` assigns the exact integer score
+
+\[
+2^{18-w}.
+\]
+
+Aggregating these scores is ranking-equivalent to a soft minimum with inverse temperature `beta = ln(2)`, while avoiding floating-point exponential and logarithmic ranking.
+
+### 5.3 Min-plus
+
+`min_plus_hamming` uses minimum Hamming weight as the tropical class score.
+
+No arbitrary continuous temperature scan, learned score, or optimized parameter search is permitted in this work package.
+
+## 6. Correctness adjudication
+
+For a true physical error `e` and emitted correction `c`, success is certified only when
+
+\[
+e\oplus c\in S,
+\]
+
+where `S` is the certified stabilizer span. Equivalently, the residual must have zero syndrome and belong to the correct stabilizer equivalence class.
+
+The evaluator therefore distinguishes:
+
+- successful stabilizer-equivalent correction;
+- nonzero residual syndrome;
+- zero residual syndrome but wrong logical coset.
+
+The following notions are deliberately not conflated:
+
+\[
+\text{syndrome satisfaction}
+\neq
+\text{minimum-weight correction}
+\neq
+\text{logical success}.
+\]
+
+## 7. Exact finite result
+
+The candidate evaluator produces the following six-cell result on the frozen `4048`-case corpus:
+
+| terminal treatment | sum-product | soft tropical | min-plus |
+|---|---:|---:|---:|
+| representative-naive marginals | `37` | `1` | `37` |
+| stabilizer-coset aggregate | `263` | `262` | `226` |
+
+Matched quotient aggregation therefore changes the number of successful frozen-corpus decisions by:
+
+- sum-product: `+226`;
+- soft tropical: `+261`;
+- min-plus: `+189`.
+
+For these matched comparisons, the default quotient treatment repairs the stated number of representative-space failures and breaks no representative-space successes.
+
+This is a finite mechanism result only. It does not establish decoder superiority outside the declared experiment.
+
+## 8. Relation to Fixture 002 baselines
+
+The evaluator independently replays the promoted Fixture 002 anchors:
+
+- exact minimum-weight coset-leader lookup: `240/4048` successful;
+- greedy syndrome descent: `125/4048` successful.
+
+Under the default class tie rule, quotient-aware sum-product records `263` successful frozen-corpus cases, which is a net `+23` relative to the exact minimum-weight lookup. That scalar difference must not be read as monotone improvement: the two decision rules disagree substantially.
+
+Relative to the exact lookup, quotient-aware sum-product:
+
+- repairs `131` exact-lookup failures;
+- breaks `108` exact-lookup successes;
+- leaves the remaining `3809` outcomes unchanged.
+
+Soft tropical similarly repairs `130` and breaks `108`; min-plus repairs `96` and breaks `110`.
+
+The experiment therefore does not promote a statement that TCM-QDEC has beaten the exact reference decoder. It demonstrates that the finite objective induced by stabilizer-class aggregation is genuinely different from minimum-weight representative selection.
+
+## 9. Tie sensitivity
+
+Winning logical classes are not always unique. The evaluator retains this degeneracy explicitly.
+
+For the frozen corpus, the success-count envelope over all permitted choices among tied winning classes is:
+
+- sum-product: `[263, 263]`;
+- soft tropical: `[262, 262]`;
+- min-plus: `[218, 263]`.
+
+Thus the aggregate success count is tie-invariant for the selected sum-product and soft-tropical reductions on this corpus, despite non-unique winning classes. The min-plus result is materially tie-sensitive; its default lowest-coset-key result is `226`.
+
+The interval `[218,263]` is part of the scientific evidence. It must not be replaced by the single default number when characterizing the min-plus mechanism.
+
+## 10. Evidence and replay
+
+The deterministic report is regenerated with:
+
+```bash
+python reference/tcm_qdec_001.py \
+  --output evidence/TCM-QDEC-001-report.json
+```
+
+The committed candidate evidence payload is:
+
+`1b19addcda5e04cf78a834b2162fe0873ed5eb15f3330995d8354906944b7122`.
+
+The replay/adversarial harness must verify, at minimum:
+
+- exact committed-evidence regeneration;
+- predecessor payload and promotion identities;
+- frozen Fixture 002 corpus identity;
+- complete `2^18` state-space geometry;
+- exact six-cell success matrix;
+- residual-syndrome and wrong-logical-coset failure classification;
+- exact decision-table identities;
+- quotient-versus-representative repair/break counts;
+- replay of Fixture 002 exact and greedy anchors;
+- tie envelopes and tie-invariance claims;
+- fail-closed rejection of semiring, predecessor, corpus, promotion, and downstream-authority drift.
+
+## 11. Claim boundary
+
+`TCM-QDEC-001` may seek bounded promotion only for the exact finite semantic comparison described above.
+
+It does **not** certify or authorize:
+
+- scalable tensor-network contraction or a scalable TCM decoder;
+- general qLDPC decoder performance;
+- practical decoder superiority;
+- BP-OSD performance or comparison claims;
+- circuit-level or phenomenological noise;
+- Kunlun or other hardware validation;
+- thresholds or pseudo-thresholds;
+- portable latency or runtime-memory claims;
+- learned decoder parameters;
+- adaptive or autonomous parameter search;
+- `TCM-QDEC-002`;
+- `QLDPC-FORGE`;
+- autonomous code, decoder, circuit, or architecture search.
+
+## 12. Promotion condition
+
+Promotion requires:
+
+1. exact protected-predecessor binding;
+2. byte-stable committed report regeneration;
+3. complete finite state-space replay;
+4. exact six-cell matrix reproduction;
+5. independent verification of matched repair/break counts;
+6. explicit retention of representative-space syndrome failures;
+7. explicit retention of min-plus tie sensitivity;
+8. green adversarial tests;
+9. fresh exact-head QTR and GCL workflows;
+10. a fresh bounded office review and Referee disposition.
+
+Until then, `TCM-QDEC-001` remains executable candidate evidence only.


### PR DESCRIPTION
## Subject

Open only `TCM-QDEC-001` above the two bounded-promoted qLDPC fixtures.

This candidate is an exact finite semantic audit of physical-representative inference versus stabilizer-coset aggregation on the protected `[[18,4,4]]` code. It does not open `TCM-QDEC-002` or `QLDPC-FORGE`.

## Exact subject

- protected base: `074612e39e1232d1644edc487914ca571189f409`
- candidate head: `cba814e5e5fb6db8fba7a8afd8211189a477eecb`
- tracking issue: #37
- Fixture 002 evidence payload: `d98c5d73f7fdf9259a35be60580dc9b6c32c5e4483cd765ed0dcba594b9299e5`
- frozen corpus SHA-256: `260b1a43cf1d777f28c475918e91a5f7cefc5d28a2bfb556338f7e30058f58a8`
- candidate evidence payload: `1b19addcda5e04cf78a834b2162fe0873ed5eb15f3330995d8354906944b7122`

## Frozen state space

The evaluator enumerates all `2^18 = 262144` one-sector physical errors and verifies `128` reachable syndromes, `2048` representatives per syndrome, stabilizer-span size `128`, and `16` stabilizer-equivalence logical classes per syndrome. Scoring remains the exact Fixture 002 weight-`0..4` corpus of `4048` cases.

## Controlled matrix

Two terminal treatments are compared under three exact semiring reductions:

- representative-naive coordinatewise marginals, with no syndrome repair;
- stabilizer-coset aggregation, with a declared deterministic class/representative tie rule;
- exact sum-product numerator for BSC `p=0.1`;
- exact base-2 soft-tropical partition score;
- min-plus Hamming weight.

All ranking arithmetic is integer exact; no floating-point ranking or parameter search is used.

## Candidate finite results

| treatment | sum-product | soft tropical | min-plus |
|---|---:|---:|---:|
| representative-naive | 37 | 1 | 37 |
| stabilizer-coset aggregate | 263 | 262 | 226 |

Matched quotient aggregation repairs `226`, `261`, and `189` representative-space failures respectively and breaks none of those matched representative-space successes.

The result is not a decoder-superiority claim. In particular, quotient-aware sum-product is net `+23` versus Fixture 002's exact minimum-weight lookup only because it repairs `131` exact-lookup failures while also breaking `108` exact-lookup successes.

## Tie sensitivity

Frozen-corpus success envelopes over all permitted choices among tied winning logical classes are:

- sum-product: `[263,263]`;
- soft tropical: `[262,262]`;
- min-plus: `[218,263]`.

The min-plus default result `226` is therefore materially tie-sensitive and is retained as such.

## Claim boundary

This PR creates no authority for scalable tensor contraction, general qLDPC decoder performance, BP-OSD comparison, circuit-level or phenomenological noise, hardware validation, thresholds, portable latency/memory claims, learned decoding, `TCM-QDEC-002`, `QLDPC-FORGE`, or autonomous search.

## Review gate

Keep this PR draft until fresh exact-head QTR/GCL replay proves:

- protected predecessor and promotion binding;
- committed evidence regeneration;
- complete `2^18` state-space geometry;
- exact six-cell result reproduction;
- Fixture 002 baseline replay;
- matched repair/break counts;
- explicit residual-syndrome and logical-coset failure classification;
- tie-envelope reproduction;
- adversarial fail-closed behavior for semiring, predecessor, promotion, corpus, and authority drift.
