### PR TITLE
Add TCM-QDEC-004 shared exact compilation

### DIFF
--- a/evidence/TCM-QDEC-004-report.json
+++ b/evidence/TCM-QDEC-004-report.json
@@ -1,0 +1,223 @@
+{
+  "adjudication": {
+    "abstract_operation_reduction_observed": true,
+    "complete_answer_cache_disallowed_and_not_used": true,
+    "downstream_authority_created": false,
+    "exact_semantics_preserved": true,
+    "memory_superiority_claim": false,
+    "nontrivial_shared_structural_object": true,
+    "outcome": "EXACT_SHARED_COMPILATION_WITH_REDUCED_DUPLICATION",
+    "runtime_superiority_claim": false
+  },
+  "basis_geometry": {
+    "factor_scope_sha256": "9b9f68ff6cf22447892c6d853defa6daf5f08c5859ffd4352500d1e11b89052d",
+    "factor_scope_size_histogram": {
+      "1": 2,
+      "2": 8,
+      "3": 8
+    },
+    "frozen_degeneracy_elimination_order": [2,4,0,1,3,5,6],
+    "reachable_selector_count": 2048,
+    "selector_seed_basis_qubits": [0,1,2,3,4,5,6,7,8,9,10],
+    "stabilizer_basis_row_indices": [0,1,2,3,4,5,6],
+    "stabilizer_span_size": 128
+  },
+  "claim_boundary": {
+    "abstract_operation_reduction_claim_only": true,
+    "adaptive_online_contraction_order_authorized": false,
+    "asymptotic_complexity_claim": false,
+    "autonomous_search_authorized": false,
+    "bounded_width_family_claim": false,
+    "bp_min_sum_bp_osd_comparison_authorized": false,
+    "circuit_level_noise_authorized": false,
+    "exact_predecessor_semantics_required": true,
+    "exact_shared_compilation_on_fixed_fixture_only": true,
+    "larger_code_authorized": false,
+    "learned_decoder_authorized": false,
+    "memory_superiority_claim": false,
+    "multi_size_scaling_authorized": false,
+    "qldpc_forge_authorized": false,
+    "repeated_syndrome_authorized": false,
+    "runtime_superiority_claim": false,
+    "selector_answer_cache_primary_object_allowed": false
+  },
+  "compiled_decisions": {
+    "min_plus_hamming": {
+      "decision_table_sha256": "88a9a766b64c7e476ac5bb4da877a2b1f6d4e88cee88cde6ea7461cc74179f3f",
+      "failure_modes": {"nonzero_residual_syndrome": 0,"zero_syndrome_wrong_logical_coset": 3822},
+      "failure_total": 3822,
+      "success_by_error_weight": {"0":1,"1":18,"2":63,"3":54,"4":90},
+      "success_total": 226
+    },
+    "soft_tropical_base_2": {
+      "decision_table_sha256": "ea2a96e3878758cd2daebd28673d943c27740a3e1c3579d8429a8a658e567393",
+      "failure_modes": {"nonzero_residual_syndrome": 0,"zero_syndrome_wrong_logical_coset": 3786},
+      "failure_total": 3786,
+      "success_by_error_weight": {"0":1,"1":18,"2":63,"3":90,"4":90},
+      "success_total": 262
+    },
+    "sum_product_bsc_p_0_1": {
+      "decision_table_sha256": "05dd32573ee965ce96caf707de3541f8be74b49317ad46b7929ef7dcf3bf64fc",
+      "failure_modes": {"nonzero_residual_syndrome": 0,"zero_syndrome_wrong_logical_coset": 3785},
+      "failure_total": 3785,
+      "success_by_error_weight": {"0":1,"1":18,"2":63,"3":91,"4":90},
+      "success_total": 263
+    }
+  },
+  "compiled_structure": {
+    "canonical_serialized_bytes_total": 65506,
+    "per_algebra": {
+      "min_plus_hamming": {
+        "canonical_serialized_bytes": 22876,
+        "canonical_sha256": "daaa544340d1d101c402f0f7be0d95eaf75c8f861fe7018f12cf29a797b35339",
+        "compile_aop": {"EXACT_COMPARE":515,"EXACT_INT_ADD":0,"EXACT_INT_MUL":0,"GF2_AND":260,"GF2_XOR":0,"NODE_INTERN":747,"TABLE_READ":1325,"TABLE_WRITE":551},
+        "compile_aop_total": 3398,
+        "elimination_trace": [
+          {"factor_count":13,"unique_nodes":149,"variable":2},
+          {"factor_count":8,"unique_nodes":257,"variable":4},
+          {"factor_count":5,"unique_nodes":341,"variable":0},
+          {"factor_count":4,"unique_nodes":365,"variable":1},
+          {"factor_count":2,"unique_nodes":381,"variable":3},
+          {"factor_count":1,"unique_nodes":387,"variable":5},
+          {"factor_count":1,"unique_nodes":388,"variable":6}
+        ],
+        "hash_cons_reuses": 359,"node_intern_attempts":747,"peak_nodes_during_compilation":388,"retained_reachable_nodes":388,"unique_nodes_created":388
+      },
+      "soft_tropical_base_2": {
+        "canonical_serialized_bytes": 21315,
+        "canonical_sha256": "e15b58e494d5ff75efd8778210d1d195701e71dea84a8d8dff4eafe02dcf2d68",
+        "compile_aop": {"EXACT_COMPARE":515,"EXACT_INT_ADD":0,"EXACT_INT_MUL":0,"GF2_AND":260,"GF2_XOR":0,"NODE_INTERN":747,"TABLE_READ":1325,"TABLE_WRITE":534},
+        "compile_aop_total": 3381,
+        "elimination_trace": [
+          {"factor_count":13,"unique_nodes":132,"variable":2},
+          {"factor_count":8,"unique_nodes":240,"variable":4},
+          {"factor_count":5,"unique_nodes":324,"variable":0},
+          {"factor_count":4,"unique_nodes":348,"variable":1},
+          {"factor_count":2,"unique_nodes":364,"variable":3},
+          {"factor_count":1,"unique_nodes":370,"variable":5},
+          {"factor_count":1,"unique_nodes":371,"variable":6}
+        ],
+        "hash_cons_reuses":376,"node_intern_attempts":747,"peak_nodes_during_compilation":371,"retained_reachable_nodes":371,"unique_nodes_created":371
+      },
+      "sum_product_bsc_p_0_1": {
+        "canonical_serialized_bytes": 21315,
+        "canonical_sha256": "74a20187b141813772400944962462b0fd4859f253b161bedc3d871231cfad8e",
+        "compile_aop": {"EXACT_COMPARE":515,"EXACT_INT_ADD":0,"EXACT_INT_MUL":0,"GF2_AND":260,"GF2_XOR":0,"NODE_INTERN":747,"TABLE_READ":1325,"TABLE_WRITE":534},
+        "compile_aop_total": 3381,
+        "elimination_trace": [
+          {"factor_count":13,"unique_nodes":132,"variable":2},
+          {"factor_count":8,"unique_nodes":240,"variable":4},
+          {"factor_count":5,"unique_nodes":324,"variable":0},
+          {"factor_count":4,"unique_nodes":348,"variable":1},
+          {"factor_count":2,"unique_nodes":364,"variable":3},
+          {"factor_count":1,"unique_nodes":370,"variable":5},
+          {"factor_count":1,"unique_nodes":371,"variable":6}
+        ],
+        "hash_cons_reuses":376,"node_intern_attempts":747,"peak_nodes_during_compilation":371,"retained_reachable_nodes":371,"unique_nodes_created":371
+      }
+    },
+    "primary_object_is_complete_answer_cache": false,
+    "retained_reachable_nodes_total": 1130,
+    "selector_parameters_enter_only_through_parameter_choice_nodes": true,
+    "selector_values_materialized_during_compilation": 0
+  },
+  "cost_accounting": {
+    "aop_total_is_runtime_model": false,
+    "aop_types": ["GF2_XOR","GF2_AND","EXACT_INT_ADD","EXACT_INT_MUL","EXACT_COMPARE","TABLE_READ","TABLE_WRITE","NODE_INTERN"],
+    "break_even_complete_sweeps": 1,
+    "compile": {
+      "aop": {"EXACT_COMPARE":1545,"EXACT_INT_ADD":0,"EXACT_INT_MUL":0,"GF2_AND":780,"GF2_XOR":0,"NODE_INTERN":2241,"TABLE_READ":3975,"TABLE_WRITE":1619},
+      "aop_total": 10160
+    },
+    "compiled_one_shot_uses_fewer_aops": true,
+    "evaluate_all_2048_selectors": {
+      "aop": {"EXACT_COMPARE":258048,"EXACT_INT_ADD":2002944,"EXACT_INT_MUL":1163264,"GF2_AND":202752,"GF2_XOR":33792,"NODE_INTERN":0,"TABLE_READ":6719488,"TABLE_WRITE":2314240},
+      "aop_total": 12694528,
+      "per_algebra": {
+        "min_plus_hamming": {
+          "aop": {"EXACT_COMPARE":258048,"EXACT_INT_ADD":1744896,"EXACT_INT_MUL":0,"GF2_AND":67584,"GF2_XOR":11264,"NODE_INTERN":0,"TABLE_READ":2263040,"TABLE_WRITE":794624},
+          "aop_total":5139456,"per_selector_aop_max":2515,"per_selector_aop_mean_denominator":2048,"per_selector_aop_mean_numerator":5139456,"per_selector_aop_min":2504,"visited_compiled_nodes_per_selector_max":388,"visited_compiled_nodes_per_selector_min":388
+        },
+        "soft_tropical_base_2": {
+          "aop": {"EXACT_COMPARE":0,"EXACT_INT_ADD":129024,"EXACT_INT_MUL":581632,"GF2_AND":67584,"GF2_XOR":11264,"NODE_INTERN":0,"TABLE_READ":2228224,"TABLE_WRITE":759808},
+          "aop_total":3777536,"per_selector_aop_max":1850,"per_selector_aop_mean_denominator":2048,"per_selector_aop_mean_numerator":3777536,"per_selector_aop_min":1839,"visited_compiled_nodes_per_selector_max":371,"visited_compiled_nodes_per_selector_min":371
+        },
+        "sum_product_bsc_p_0_1": {
+          "aop": {"EXACT_COMPARE":0,"EXACT_INT_ADD":129024,"EXACT_INT_MUL":581632,"GF2_AND":67584,"GF2_XOR":11264,"NODE_INTERN":0,"TABLE_READ":2228224,"TABLE_WRITE":759808},
+          "aop_total":3777536,"per_selector_aop_max":1850,"per_selector_aop_mean_denominator":2048,"per_selector_aop_mean_numerator":3777536,"per_selector_aop_min":1839,"visited_compiled_nodes_per_selector_max":371,"visited_compiled_nodes_per_selector_min":371
+        }
+      }
+    },
+    "one_shot": {"aop_total":12704688},
+    "one_shot_aop_reduction": 1411152,
+    "repeated_complete_sweep_formula": "C_compile + k*C_eval_all versus k*C_003_all",
+    "runtime_or_memory_superiority_inferred": false,
+    "tcm_qdec_003_reinstrumented_classwise_replay": {
+      "aop": {"EXACT_COMPARE":258048,"EXACT_INT_ADD":3815424,"EXACT_INT_MUL":2371584,"GF2_AND":2279424,"GF2_XOR":832512,"NODE_INTERN":0,"TABLE_READ":3557376,"TABLE_WRITE":1001472},
+      "aop_total":14115840,
+      "original_assignment_evaluations_preserved":774144,
+      "original_counters_not_translated_to_aop":true,
+      "original_predecessor_transition_relaxations_preserved":98298,
+      "per_algebra": {
+        "min_plus_hamming": {"aop":{"EXACT_COMPARE":258048,"EXACT_INT_ADD":3557376,"EXACT_INT_MUL":0,"GF2_AND":759808,"GF2_XOR":277504,"NODE_INTERN":0,"TABLE_READ":1185792,"TABLE_WRITE":333824},"aop_total":6372352},
+        "soft_tropical_base_2": {"aop":{"EXACT_COMPARE":0,"EXACT_INT_ADD":129024,"EXACT_INT_MUL":1185792,"GF2_AND":759808,"GF2_XOR":277504,"NODE_INTERN":0,"TABLE_READ":1185792,"TABLE_WRITE":333824},"aop_total":3871744},
+        "sum_product_bsc_p_0_1": {"aop":{"EXACT_COMPARE":0,"EXACT_INT_ADD":129024,"EXACT_INT_MUL":1185792,"GF2_AND":759808,"GF2_XOR":277504,"NODE_INTERN":0,"TABLE_READ":1185792,"TABLE_WRITE":333824},"aop_total":3871744}
+      }
+    }
+  },
+  "decision_rule": {"class_tie_break":"lowest_canonical_stabilizer_coset_key","representative_within_class":"lowest_hamming_weight_then_integer","winning_class":"exact_semiring_optimum"},
+  "evaluator_version": "0.1.0",
+  "experiment_id": "TCM-QDEC-004",
+  "payload_sha256": "a5c7e59fa849ddc37c070d78d4a4dab8b07ae5ceccfecefeb5a20f4ae0dc83a7",
+  "predecessor": {
+    "evidence_path":"evidence/TCM-QDEC-003-report.json",
+    "evidence_payload_sha256":"f0ecdae04f3da4f0508454da59ce406a4e6c461f88f1784279cb6d7e360b595f",
+    "experiment_id":"TCM-QDEC-003",
+    "promotion_main_commit":"4524be6fd51eb78b627e4303cd713b5c215fc7a8",
+    "promotion_record_path":"reviews/QTR-TCM-QDEC-REVIEW-003/promotion-record.json",
+    "registry_path":"registry/tcm-qdec-003.json",
+    "reviewed_head":"968029c156a3d668a0adc9adce850b62cd249671",
+    "scientific_merge_commit":"2925a41343c8e4592c1bf558d86ea461e0e1c7d4"
+  },
+  "representation": {
+    "anti_cache_rule":"complete_selector_answer_tables_are_not_admissible_primary_compiled_objects",
+    "canonicalization":"hash_cons_exact_expression_nodes_with_commutative_binary_operand_order",
+    "compile_policy":"symbolically_eliminate_z_keep_a_explicit",
+    "frozen_degeneracy_elimination_order":[2,4,0,1,3,5,6],
+    "kind":"exact_selector_parametric_hash_consed_expression_dag",
+    "operation_taxonomy":["GF2_XOR","GF2_AND","EXACT_INT_ADD","EXACT_INT_MUL","EXACT_COMPARE","TABLE_READ","TABLE_WRITE","NODE_INTERN"],
+    "parameter_interface":"eleven_boolean_selector_coordinates",
+    "physical_variable_count":18,
+    "primary_full_physical_state_enumeration":false,
+    "primary_full_selector_enumeration_during_compilation":false,
+    "reachable_selector_count":2048,
+    "selector_parameter_count":11,
+    "selector_seed_basis_qubits":[0,1,2,3,4,5,6,7,8,9,10],
+    "stabilizer_basis_row_indices":[0,1,2,3,4,5,6],
+    "stabilizer_generator_count":7
+  },
+  "semantic_equivalence": {
+    "canonical_class_mapping_sha256":"0d907375404e37533a3dd182eccea7d6a3fd6637801745f8f5b39b7c4b683f8f",
+    "class_mapping_entries_checked":2048,"class_mapping_exactly_equal":true,"decision_entries_checked":384,
+    "decision_table_sha256":{"min_plus_hamming":"88a9a766b64c7e476ac5bb4da877a2b1f6d4e88cee88cde6ea7461cc74179f3f","soft_tropical_base_2":"ea2a96e3878758cd2daebd28673d943c27740a3e1c3579d8429a8a658e567393","sum_product_bsc_p_0_1":"05dd32573ee965ce96caf707de3541f8be74b49317ad46b7929ef7dcf3bf64fc"},
+    "decision_tables_exactly_equal":true,
+    "frozen_corpus_success_totals":{"min_plus_hamming":226,"soft_tropical_base_2":262,"sum_product_bsc_p_0_1":263},
+    "score_entries_checked":6144,
+    "score_table_sha256":{"min_plus_hamming":"178a357cd13b2b9bbab03bad09f08efafecf37f2b59080bb3a6107e552e3b524","soft_tropical_base_2":"00c4b4c7612b6d05847963c4f8d432160cb2d6ec06fa4813700220461102bad5","sum_product_bsc_p_0_1":"1b6bd71b9b05f169f57103ae71cd8b540f88e05dbe0302f2b4d9c2562a76a7be"},
+    "score_tables_exactly_equal":true,
+    "tie_envelopes":{"min_plus_hamming":[218,263],"soft_tropical_base_2":[262,262],"sum_product_bsc_p_0_1":[263,263]},
+    "winning_class_tie_set_cells_checked":384,"winning_class_tie_sets_exactly_equal":true,
+    "winning_class_tie_sets_sha256":{"min_plus_hamming":"1991fe00aaec2f8ce1163ca7b4192054002a2ef176d4839d6883c01f4e724007","soft_tropical_base_2":"bf4297273ca05b1506bde6f5305464e5affdf78ba31b40e20a0fada3e26dd982","sum_product_bsc_p_0_1":"3778c019c7e235d916fa27616f83a9f8251a8c2a0276e09e0ea6dc1a6125cd60"}
+  },
+  "semirings": {
+    "min_plus_hamming":{"interpretation":"minimum Hamming-weight tropical score","kind":"min_plus","local_bit_costs":[0,1],"score_direction":"minimize"},
+    "soft_tropical_base_2":{"interpretation":"exact partition score equivalent in ranking to beta=ln(2) soft-min","kind":"soft_tropical","local_bit_weights":[2,1],"score_direction":"maximize"},
+    "sum_product_bsc_p_0_1":{"interpretation":"exact numerator proportional to BSC p=0.1 likelihood","kind":"sum_product","local_bit_weights":[9,1],"score_direction":"maximize"}
+  },
+  "status":"candidate_executable_not_promoted",
+  "tie_sensitivity": {
+    "min_plus_hamming":{"default_lowest_key_success_count":226,"frozen_corpus_success_count_envelope_over_winning_class_ties":{"max":263,"min":218},"success_count_invariant_under_winning_class_tie_break":false,"winning_class_count_histogram":{"1":37,"10":45,"3":45,"6":1}},
+    "soft_tropical_base_2":{"default_lowest_key_success_count":262,"frozen_corpus_success_count_envelope_over_winning_class_ties":{"max":262,"min":262},"success_count_invariant_under_winning_class_tie_break":true,"winning_class_count_histogram":{"1":37,"10":1,"3":45,"4":45}},
+    "sum_product_bsc_p_0_1":{"default_lowest_key_success_count":263,"frozen_corpus_success_count_envelope_over_winning_class_ties":{"max":263,"min":263},"success_count_invariant_under_winning_class_tie_break":true,"winning_class_count_histogram":{"1":37,"3":45,"4":45,"6":1}}
+  }
+}

--- a/reference/tcm_qdec_004.py
+++ b/reference/tcm_qdec_004.py
@@ -1,0 +1,985 @@
+#!/usr/bin/env python3
+"""TCM-QDEC-004: exact selector-parametric shared compilation audit.
+
+The primary path symbolically eliminates the seven promoted stabilizer-degeneracy
+variables while retaining the eleven promoted selector coordinates as explicit
+parameters.  It compiles a canonical hash-consed exact expression DAG for each
+algebra, then reuses that DAG across all 2048 selector evaluations.
+
+The compiled DAG is structural: it contains parameter-choice and semiring
+operation nodes, not a table of the 2048 evaluated selector answers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import itertools
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+EVALUATOR_VERSION = "0.1.0"
+
+PREDECESSOR_PAYLOAD = "f0ecdae04f3da4f0508454da59ce406a4e6c461f88f1784279cb6d7e360b595f"
+PREDECESSOR_SCIENTIFIC_MERGE = "2925a41343c8e4592c1bf558d86ea461e0e1c7d4"
+PREDECESSOR_PROMOTION_MAIN = "4524be6fd51eb78b627e4303cd713b5c215fc7a8"
+PREDECESSOR_PROMOTION_RECORD = "QTR-TCM-QDEC-REVIEW-003-PROMOTION"
+PREDECESSOR_REVIEWED_HEAD = "968029c156a3d668a0adc9adce850b62cd249671"
+
+EXPECTED_SCOPE_SHA = "9b9f68ff6cf22447892c6d853defa6daf5f08c5859ffd4352500d1e11b89052d"
+EXPECTED_SCORE_SHA = {
+    "sum_product_bsc_p_0_1": "1b6bd71b9b05f169f57103ae71cd8b540f88e05dbe0302f2b4d9c2562a76a7be",
+    "soft_tropical_base_2": "00c4b4c7612b6d05847963c4f8d432160cb2d6ec06fa4813700220461102bad5",
+    "min_plus_hamming": "178a357cd13b2b9bbab03bad09f08efafecf37f2b59080bb3a6107e552e3b524",
+}
+EXPECTED_MAPPING_SHA = "0d907375404e37533a3dd182eccea7d6a3fd6637801745f8f5b39b7c4b683f8f"
+EXPECTED_DECISION_SHA = {
+    "sum_product_bsc_p_0_1": "05dd32573ee965ce96caf707de3541f8be74b49317ad46b7929ef7dcf3bf64fc",
+    "soft_tropical_base_2": "ea2a96e3878758cd2daebd28673d943c27740a3e1c3579d8429a8a658e567393",
+    "min_plus_hamming": "88a9a766b64c7e476ac5bb4da877a2b1f6d4e88cee88cde6ea7461cc74179f3f",
+}
+EXPECTED_TIE_SHA = {
+    "sum_product_bsc_p_0_1": "3778c019c7e235d916fa27616f83a9f8251a8c2a0276e09e0ea6dc1a6125cd60",
+    "soft_tropical_base_2": "bf4297273ca05b1506bde6f5305464e5affdf78ba31b40e20a0fada3e26dd982",
+    "min_plus_hamming": "1991fe00aaec2f8ce1163ca7b4192054002a2ef176d4839d6883c01f4e724007",
+}
+EXPECTED_SUCCESS = {
+    "sum_product_bsc_p_0_1": 263,
+    "soft_tropical_base_2": 262,
+    "min_plus_hamming": 226,
+}
+EXPECTED_TIE_ENVELOPES = {
+    "sum_product_bsc_p_0_1": [263, 263],
+    "soft_tropical_base_2": [262, 262],
+    "min_plus_hamming": [218, 263],
+}
+EXPECTED_ORDER = [2, 4, 0, 1, 3, 5, 6]
+EXPECTED_STABILIZER_BASIS = [0, 1, 2, 3, 4, 5, 6]
+EXPECTED_SELECTOR_BASIS = list(range(11))
+
+PREDECESSOR = {
+    "experiment_id": "TCM-QDEC-003",
+    "registry_path": "registry/tcm-qdec-003.json",
+    "evidence_path": "evidence/TCM-QDEC-003-report.json",
+    "evidence_payload_sha256": PREDECESSOR_PAYLOAD,
+    "reviewed_head": PREDECESSOR_REVIEWED_HEAD,
+    "scientific_merge_commit": PREDECESSOR_SCIENTIFIC_MERGE,
+    "promotion_main_commit": PREDECESSOR_PROMOTION_MAIN,
+    "promotion_record_path": "reviews/QTR-TCM-QDEC-REVIEW-003/promotion-record.json",
+}
+
+SEMIRINGS = {
+    "min_plus_hamming": {
+        "interpretation": "minimum Hamming-weight tropical score",
+        "kind": "min_plus",
+        "local_bit_costs": [0, 1],
+        "score_direction": "minimize",
+    },
+    "soft_tropical_base_2": {
+        "interpretation": "exact partition score equivalent in ranking to beta=ln(2) soft-min",
+        "kind": "soft_tropical",
+        "local_bit_weights": [2, 1],
+        "score_direction": "maximize",
+    },
+    "sum_product_bsc_p_0_1": {
+        "interpretation": "exact numerator proportional to BSC p=0.1 likelihood",
+        "kind": "sum_product",
+        "local_bit_weights": [9, 1],
+        "score_direction": "maximize",
+    },
+}
+
+DECISION_RULE = {
+    "winning_class": "exact_semiring_optimum",
+    "class_tie_break": "lowest_canonical_stabilizer_coset_key",
+    "representative_within_class": "lowest_hamming_weight_then_integer",
+}
+
+AOP_TYPES = [
+    "GF2_XOR",
+    "GF2_AND",
+    "EXACT_INT_ADD",
+    "EXACT_INT_MUL",
+    "EXACT_COMPARE",
+    "TABLE_READ",
+    "TABLE_WRITE",
+    "NODE_INTERN",
+]
+
+REPRESENTATION = {
+    "kind": "exact_selector_parametric_hash_consed_expression_dag",
+    "physical_variable_count": 18,
+    "stabilizer_generator_count": 7,
+    "selector_parameter_count": 11,
+    "reachable_selector_count": 2048,
+    "stabilizer_basis_row_indices": EXPECTED_STABILIZER_BASIS,
+    "selector_seed_basis_qubits": EXPECTED_SELECTOR_BASIS,
+    "frozen_degeneracy_elimination_order": EXPECTED_ORDER,
+    "compile_policy": "symbolically_eliminate_z_keep_a_explicit",
+    "parameter_interface": "eleven_boolean_selector_coordinates",
+    "canonicalization": "hash_cons_exact_expression_nodes_with_commutative_binary_operand_order",
+    "anti_cache_rule": "complete_selector_answer_tables_are_not_admissible_primary_compiled_objects",
+    "primary_full_selector_enumeration_during_compilation": False,
+    "primary_full_physical_state_enumeration": False,
+    "operation_taxonomy": AOP_TYPES,
+}
+
+CLAIM_BOUNDARY = {
+    "exact_shared_compilation_on_fixed_fixture_only": True,
+    "exact_predecessor_semantics_required": True,
+    "selector_answer_cache_primary_object_allowed": False,
+    "abstract_operation_reduction_claim_only": True,
+    "runtime_superiority_claim": False,
+    "memory_superiority_claim": False,
+    "asymptotic_complexity_claim": False,
+    "bounded_width_family_claim": False,
+    "larger_code_authorized": False,
+    "multi_size_scaling_authorized": False,
+    "bp_min_sum_bp_osd_comparison_authorized": False,
+    "circuit_level_noise_authorized": False,
+    "repeated_syndrome_authorized": False,
+    "learned_decoder_authorized": False,
+    "adaptive_online_contraction_order_authorized": False,
+    "qldpc_forge_authorized": False,
+    "autonomous_search_authorized": False,
+}
+
+SOURCE_LOGICAL_Z = [
+    ["L0", "L2", "L3", "L4", "L8", "R0"],
+    ["L0", "L2", "L4", "L5", "L6", "L7"],
+    ["L1", "L2", "L7", "R1"],
+    ["L0", "L1", "L6", "R0"],
+]
+
+
+def digest(payload: Any) -> str:
+    raw = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def i2b(value: int, width: int) -> str:
+    return "".join("1" if value & (1 << index) else "0" for index in range(width))
+
+
+def exact_keys(mapping: dict[str, Any], expected: set[str], where: str) -> None:
+    if set(mapping) != expected:
+        raise ValueError(f"{where} key mismatch")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_registry(path: Path) -> dict[str, Any]:
+    data = load_json(path)
+    exact_keys(data, {"registry_version", "experiments"}, "registry")
+    if data["registry_version"] != "0.1.0" or not isinstance(data["experiments"], list):
+        raise ValueError("invalid TCM-QDEC-004 registry")
+    matches = [x for x in data["experiments"] if x.get("experiment_id") == "TCM-QDEC-004"]
+    if len(matches) != 1:
+        raise ValueError("TCM-QDEC-004 must appear exactly once")
+    experiment = matches[0]
+    expected = {
+        "experiment_id", "programme", "status", "predecessor", "representation",
+        "semirings", "decision_rule", "claim_boundary",
+    }
+    exact_keys(experiment, expected, "experiment")
+    if experiment["programme"] != "QTR" or experiment["status"] != "candidate_executable_not_promoted":
+        raise ValueError("TCM-QDEC-004 identity/status changed")
+    for name, observed, wanted in (
+        ("predecessor", experiment["predecessor"], PREDECESSOR),
+        ("representation", experiment["representation"], REPRESENTATION),
+        ("semirings", experiment["semirings"], SEMIRINGS),
+        ("decision_rule", experiment["decision_rule"], DECISION_RULE),
+        ("claim_boundary", experiment["claim_boundary"], CLAIM_BOUNDARY),
+    ):
+        if observed != wanted:
+            raise ValueError(f"{name} unexpectedly changed")
+    return experiment
+
+
+def validate_predecessor(
+    tcm3_registry: dict[str, Any], tcm3_evidence: dict[str, Any], tcm3_promotion: dict[str, Any]
+) -> None:
+    matches = [x for x in tcm3_registry.get("experiments", []) if x.get("experiment_id") == "TCM-QDEC-003"]
+    if len(matches) != 1 or matches[0].get("status") != "candidate_executable_not_promoted":
+        raise ValueError("TCM-QDEC-003 immutable registry identity changed")
+    if tcm3_evidence.get("experiment_id") != "TCM-QDEC-003":
+        raise ValueError("TCM-QDEC-003 evidence identity changed")
+    if tcm3_evidence.get("status") != "candidate_executable_not_promoted":
+        raise ValueError("TCM-QDEC-003 evidence status changed")
+    if tcm3_evidence.get("payload_sha256") != PREDECESSOR_PAYLOAD:
+        raise ValueError("TCM-QDEC-003 payload changed")
+    unsigned = dict(tcm3_evidence)
+    unsigned.pop("payload_sha256", None)
+    if digest(unsigned) != PREDECESSOR_PAYLOAD:
+        raise ValueError("TCM-QDEC-003 payload fails self-verification")
+    geometry = tcm3_evidence.get("basis_geometry", {})
+    if geometry.get("stabilizer_basis_row_indices") != EXPECTED_STABILIZER_BASIS:
+        raise ValueError("TCM-QDEC-003 stabilizer basis changed")
+    if geometry.get("selector_seed_basis_qubits") != EXPECTED_SELECTOR_BASIS:
+        raise ValueError("TCM-QDEC-003 selector basis changed")
+    if geometry.get("factor_scope_sha256") != EXPECTED_SCOPE_SHA:
+        raise ValueError("TCM-QDEC-003 factor scopes changed")
+    audit = tcm3_evidence.get("elimination_order_audit", {})
+    if audit.get("frozen_lexicographically_first_optimal_order") != EXPECTED_ORDER:
+        raise ValueError("TCM-QDEC-003 elimination order changed")
+    contraction = tcm3_evidence.get("degeneracy_contraction", {})
+    if contraction.get("score_table_sha256") != EXPECTED_SCORE_SHA:
+        raise ValueError("TCM-QDEC-003 score identities changed")
+    if contraction.get("canonical_class_mapping_sha256") != EXPECTED_MAPPING_SHA:
+        raise ValueError("TCM-QDEC-003 mapping identity changed")
+    if tcm3_evidence.get("winning_class_tie_sets_sha256") != EXPECTED_TIE_SHA:
+        raise ValueError("TCM-QDEC-003 tie identities changed")
+    for algebra, expected in EXPECTED_DECISION_SHA.items():
+        cell = tcm3_evidence.get("degeneracy_decisions", {}).get(algebra, {})
+        if cell.get("decision_table_sha256") != expected or cell.get("success_total") != EXPECTED_SUCCESS[algebra]:
+            raise ValueError(f"TCM-QDEC-003 decision identity changed: {algebra}")
+    if tcm3_promotion.get("record_id") != PREDECESSOR_PROMOTION_RECORD:
+        raise ValueError("TCM-QDEC-003 promotion identity changed")
+    if tcm3_promotion.get("status") != "referee_promoted_bounded":
+        raise ValueError("TCM-QDEC-003 is not bounded promoted")
+    if tcm3_promotion.get("reviewed_head") != PREDECESSOR_REVIEWED_HEAD:
+        raise ValueError("TCM-QDEC-003 reviewed head changed")
+    if tcm3_promotion.get("scientific_merge_commit") != PREDECESSOR_SCIENTIFIC_MERGE:
+        raise ValueError("TCM-QDEC-003 scientific merge changed")
+    snapshot = tcm3_promotion.get("reviewed_snapshot", {})
+    if snapshot.get("evidence_payload_sha256") != PREDECESSOR_PAYLOAD or snapshot.get("snapshot_preserved_byte_for_byte") is not True:
+        raise ValueError("TCM-QDEC-003 reviewed snapshot changed")
+    if "TCM-QDEC-004" not in tcm3_promotion.get("excluded_scope", []):
+        raise ValueError("TCM-QDEC-003 downstream gate changed")
+
+
+def identity(n: int) -> list[list[int]]:
+    return [[int(i == j) for j in range(n)] for i in range(n)]
+
+
+def cyclic_shift(n: int) -> list[list[int]]:
+    return [[int(j == (i + 1) % n) for j in range(n)] for i in range(n)]
+
+
+def transpose(matrix: list[list[int]]) -> list[list[int]]:
+    return [list(column) for column in zip(*matrix)]
+
+
+def matmul_mod2(left: list[list[int]], right: list[list[int]]) -> list[list[int]]:
+    right_t = transpose(right)
+    return [[sum(a * b for a, b in zip(row, col)) % 2 for col in right_t] for row in left]
+
+
+def matrix_add_mod2(*matrices: list[list[int]]) -> list[list[int]]:
+    return [[sum(matrix[i][j] for matrix in matrices) % 2 for j in range(len(matrices[0][0]))] for i in range(len(matrices[0]))]
+
+
+def matrix_power_mod2(matrix: list[list[int]], exponent: int) -> list[list[int]]:
+    result = identity(len(matrix))
+    base = matrix
+    while exponent:
+        if exponent & 1:
+            result = matmul_mod2(result, base)
+        base = matmul_mod2(base, base)
+        exponent >>= 1
+    return result
+
+
+def kron(left: list[list[int]], right: list[list[int]]) -> list[list[int]]:
+    return [[left[i][j] * right[r][c] for j in range(len(left[0])) for c in range(len(right[0]))] for i in range(len(left)) for r in range(len(right))]
+
+
+def row_to_int(row: list[int]) -> int:
+    return sum(bit << index for index, bit in enumerate(row))
+
+
+def parse_operator(labels: list[str]) -> int:
+    value = 0
+    for label in labels:
+        local = int(label[1:])
+        index = local if label[0] == "L" else 9 + local
+        value |= 1 << index
+    return value
+
+
+def construct_code() -> tuple[list[int], list[int]]:
+    x = kron(cyclic_shift(3), identity(3))
+    y = kron(identity(3), cyclic_shift(3))
+    A = matrix_add_mod2(matrix_power_mod2(x, 1), matrix_power_mod2(y, 0), matrix_power_mod2(y, 2))
+    B = matrix_add_mod2(matrix_power_mod2(y, 1), matrix_power_mod2(x, 0), matrix_power_mod2(x, 2))
+    rows = [row_to_int(left + right) for left, right in zip(A, B)]
+    logical_z = [parse_operator(labels) for labels in SOURCE_LOGICAL_Z]
+    return rows, logical_z
+
+
+def syndrome(error: int, rows: list[int]) -> int:
+    return sum((((error & row).bit_count() & 1) << index) for index, row in enumerate(rows))
+
+
+def logical_label(error: int, logical_z: list[int]) -> int:
+    return sum((((error & op).bit_count() & 1) << index) for index, op in enumerate(logical_z))
+
+
+def combined_selector(error: int, rows: list[int], logical_z: list[int]) -> int:
+    return syndrome(error, rows) | (logical_label(error, logical_z) << len(rows))
+
+
+def gf2_span(vectors: list[int]) -> set[int]:
+    out = {0}
+    for vector in vectors:
+        out |= {value ^ vector for value in tuple(out)}
+    return out
+
+
+class Ledger:
+    def __init__(self) -> None:
+        self.counts: Counter[str] = Counter()
+
+    def add(self, kind: str, count: int = 1) -> None:
+        if kind not in AOP_TYPES:
+            raise ValueError(f"unknown AOP type: {kind}")
+        self.counts[kind] += count
+
+    def vector(self) -> dict[str, int]:
+        return {kind: self.counts[kind] for kind in AOP_TYPES}
+
+    def total(self) -> int:
+        return sum(self.counts.values())
+
+
+class ExpressionDAG:
+    def __init__(self, ledger: Ledger) -> None:
+        self.ledger = ledger
+        self.nodes: list[tuple[Any, ...]] = []
+        self.interned: dict[tuple[Any, ...], int] = {}
+        self.peak_nodes = 0
+
+    def _intern(self, node: tuple[Any, ...]) -> int:
+        if node[0] in {"MUL", "ADD", "MPMUL", "MPMIN"}:
+            op, left, right = node
+            self.ledger.add("EXACT_COMPARE")
+            if left > right:
+                left, right = right, left
+            node = (op, left, right)
+        self.ledger.add("NODE_INTERN")
+        self.ledger.add("TABLE_READ")
+        if node in self.interned:
+            return self.interned[node]
+        index = len(self.nodes)
+        self.nodes.append(node)
+        self.interned[node] = index
+        self.ledger.add("TABLE_WRITE")
+        self.peak_nodes = max(self.peak_nodes, len(self.nodes))
+        return index
+
+    def terminal(self, value: Any) -> int:
+        return self._intern(("T", repr(value), value))
+
+    def parameter_choice(self, parameter: int, low: int, high: int) -> int:
+        if low == high:
+            return low
+        return self._intern(("ITE", parameter, low, high))
+
+    def binary(self, operation: str, left: int, right: int) -> int:
+        return self._intern((operation, left, right))
+
+    def evaluate(self, root: int, selector_coordinate: int, ledger: Ledger) -> tuple[Any, int]:
+        memo: dict[int, Any] = {}
+
+        def visit(node_id: int) -> Any:
+            ledger.add("TABLE_READ")
+            if node_id in memo:
+                return memo[node_id]
+            ledger.add("TABLE_READ")
+            node = self.nodes[node_id]
+            kind = node[0]
+            if kind == "T":
+                value = node[2]
+            elif kind == "ITE":
+                ledger.add("GF2_AND")
+                branch = node[3] if selector_coordinate & (1 << node[1]) else node[2]
+                value = visit(branch)
+            else:
+                left = visit(node[1])
+                right = visit(node[2])
+                if kind == "MUL":
+                    ledger.add("EXACT_INT_MUL")
+                    value = left * right
+                elif kind == "ADD":
+                    ledger.add("EXACT_INT_ADD")
+                    value = left + right
+                elif kind == "MPMUL":
+                    ledger.add("EXACT_INT_ADD", 3)
+                    value = (
+                        (left[0][0] + right[0][0], left[0][1] + right[0][1]),
+                        left[1] + right[1],
+                    )
+                elif kind == "MPMIN":
+                    ledger.add("EXACT_COMPARE", 2)
+                    value = (min(left[0], right[0]), min(left[1], right[1]))
+                else:
+                    raise AssertionError(f"unknown expression node: {kind}")
+            memo[node_id] = value
+            ledger.add("TABLE_WRITE")
+            return value
+
+        return visit(root), len(memo)
+
+    def canonical_object(self, root: int) -> dict[str, Any]:
+        seen: set[int] = set()
+        order: list[int] = []
+
+        def visit(node_id: int) -> None:
+            if node_id in seen:
+                return
+            node = self.nodes[node_id]
+            if node[0] == "ITE":
+                visit(node[2])
+                visit(node[3])
+            elif node[0] in {"MUL", "ADD", "MPMUL", "MPMIN"}:
+                visit(node[1])
+                visit(node[2])
+            seen.add(node_id)
+            order.append(node_id)
+
+        visit(root)
+        remap = {old: new for new, old in enumerate(order)}
+        records: list[dict[str, Any]] = []
+        for old in order:
+            node = self.nodes[old]
+            if node[0] == "T":
+                records.append({"kind": "terminal", "value": node[2]})
+            elif node[0] == "ITE":
+                records.append({
+                    "kind": "parameter_choice",
+                    "parameter": node[1],
+                    "low": remap[node[2]],
+                    "high": remap[node[3]],
+                })
+            else:
+                records.append({
+                    "kind": "binary",
+                    "operation": node[0],
+                    "left": remap[node[1]],
+                    "right": remap[node[2]],
+                })
+        return {"root": remap[root], "nodes": records}
+
+
+def terminal_value(kind: str, qubit: int, bit: int) -> Any:
+    if kind == "sum9":
+        return 9 if bit == 0 else 1
+    if kind == "sum2":
+        return 2 if bit == 0 else 1
+    integer = (1 << qubit) if bit else 0
+    return ((bit, integer), integer)
+
+
+def compile_symbolic(kind: str, scopes: list[tuple[int, ...]]) -> tuple[ExpressionDAG, int, dict[str, Any]]:
+    ledger = Ledger()
+    dag = ExpressionDAG(ledger)
+    factors: list[tuple[tuple[int, ...], list[int]]] = []
+
+    for qubit, scope in enumerate(scopes):
+        table: list[int] = []
+        for assignment in range(1 << len(scope)):
+            ledger.add("GF2_AND", len(scope))
+            parity = assignment.bit_count() & 1
+            low = dag.terminal(terminal_value(kind, qubit, parity))
+            if qubit < 11:
+                high = dag.terminal(terminal_value(kind, qubit, parity ^ 1))
+                expression = dag.parameter_choice(qubit, low, high)
+            else:
+                expression = low
+            table.append(expression)
+            ledger.add("TABLE_WRITE")
+        factors.append((scope, table))
+
+    def combine(expressions: list[int]) -> int:
+        operation = "MUL" if kind in {"sum9", "sum2"} else "MPMUL"
+        result = expressions[0]
+        for expression in expressions[1:]:
+            result = dag.binary(operation, result, expression)
+        return result
+
+    def marginal(left: int, right: int) -> int:
+        operation = "ADD" if kind in {"sum9", "sum2"} else "MPMIN"
+        return dag.binary(operation, left, right)
+
+    trace: list[dict[str, Any]] = []
+    for variable in EXPECTED_ORDER:
+        involved = [factor for factor in factors if variable in factor[0]]
+        rest = [factor for factor in factors if variable not in factor[0]]
+        union = tuple(sorted(set().union(*(set(scope) for scope, _ in involved))))
+        output_scope = tuple(item for item in union if item != variable)
+        output: list[int] = []
+        for output_assignment in range(1 << len(output_scope)):
+            bits = {item: (output_assignment >> position) & 1 for position, item in enumerate(output_scope)}
+            branches: list[int] = []
+            for variable_bit in (0, 1):
+                bits[variable] = variable_bit
+                expressions: list[int] = []
+                for scope, table in involved:
+                    index = sum(bits[item] << position for position, item in enumerate(scope))
+                    ledger.add("TABLE_READ")
+                    expressions.append(table[index])
+                branches.append(combine(expressions))
+            output.append(marginal(branches[0], branches[1]))
+            ledger.add("TABLE_WRITE")
+        rest.append((output_scope, output))
+        factors = rest
+        trace.append({"variable": variable, "unique_nodes": len(dag.nodes), "factor_count": len(factors)})
+
+    root = combine([table[0] for scope, table in factors])
+    compiled = dag.canonical_object(root)
+    encoded = json.dumps(compiled, sort_keys=True, separators=(",", ":"), ensure_ascii=True, allow_nan=False).encode("utf-8")
+    metadata = {
+        "canonical_sha256": digest(compiled),
+        "canonical_serialized_bytes": len(encoded),
+        "retained_reachable_nodes": len(compiled["nodes"]),
+        "unique_nodes_created": len(dag.nodes),
+        "peak_nodes_during_compilation": dag.peak_nodes,
+        "node_intern_attempts": ledger.counts["NODE_INTERN"],
+        "hash_cons_reuses": ledger.counts["NODE_INTERN"] - len(dag.nodes),
+        "compile_aop": ledger.vector(),
+        "compile_aop_total": ledger.total(),
+        "elimination_trace": trace,
+    }
+    return dag, root, metadata
+
+
+def multiply_plain(values: list[Any], kind: str, ledger: Ledger) -> Any:
+    if kind in {"sum9", "sum2"}:
+        result = 1
+        for value in values:
+            ledger.add("EXACT_INT_MUL")
+            result *= value
+        return result
+    weight = representative = canonical = 0
+    for (delta, integer), key in values:
+        ledger.add("EXACT_INT_ADD", 3)
+        weight += delta
+        representative += integer
+        canonical += key
+    return ((weight, representative), canonical)
+
+
+def marginal_plain(left: Any, right: Any, kind: str, ledger: Ledger) -> Any:
+    if kind in {"sum9", "sum2"}:
+        ledger.add("EXACT_INT_ADD")
+        return left + right
+    ledger.add("EXACT_COMPARE", 2)
+    return (min(left[0], right[0]), min(left[1], right[1]))
+
+
+def classwise_contract(seed: int, scopes: list[tuple[int, ...]], kind: str, ledger: Ledger) -> Any:
+    factors: list[tuple[tuple[int, ...], list[Any]]] = []
+    for qubit, scope in enumerate(scopes):
+        table: list[Any] = []
+        for assignment in range(1 << len(scope)):
+            ledger.add("GF2_AND")
+            bit = (seed >> qubit) & 1
+            for position in range(len(scope)):
+                ledger.add("GF2_AND")
+                if assignment & (1 << position):
+                    ledger.add("GF2_XOR")
+                    bit ^= 1
+            table.append(terminal_value(kind, qubit, bit))
+            ledger.add("TABLE_WRITE")
+        factors.append((scope, table))
+
+    for variable in EXPECTED_ORDER:
+        involved = [factor for factor in factors if variable in factor[0]]
+        rest = [factor for factor in factors if variable not in factor[0]]
+        union = tuple(sorted(set().union(*(set(scope) for scope, _ in involved))))
+        output_scope = tuple(item for item in union if item != variable)
+        output: list[Any] = []
+        for output_assignment in range(1 << len(output_scope)):
+            bits = {item: (output_assignment >> position) & 1 for position, item in enumerate(output_scope)}
+            aggregate: Any | None = None
+            for variable_bit in (0, 1):
+                bits[variable] = variable_bit
+                values: list[Any] = []
+                for scope, table in involved:
+                    index = sum(bits[item] << position for position, item in enumerate(scope))
+                    ledger.add("TABLE_READ")
+                    values.append(table[index])
+                joint = multiply_plain(values, kind, ledger)
+                aggregate = joint if aggregate is None else marginal_plain(aggregate, joint, kind, ledger)
+            output.append(aggregate)
+            ledger.add("TABLE_WRITE")
+        rest.append((output_scope, output))
+        factors = rest
+
+    values: list[Any] = []
+    for scope, table in factors:
+        if scope:
+            raise AssertionError("non-scalar factor remains")
+        ledger.add("TABLE_READ")
+        values.append(table[0])
+    return multiply_plain(values, kind, ledger)
+
+
+def selector_from_coordinate(coordinate: int, selector_columns: list[int], ledger: Ledger) -> int:
+    selector = 0
+    for qubit in EXPECTED_SELECTOR_BASIS:
+        ledger.add("GF2_AND")
+        if coordinate & (1 << qubit):
+            ledger.add("GF2_XOR")
+            selector ^= selector_columns[qubit]
+    return selector
+
+
+def make_corpus(n: int = 18, maximum_weight: int = 4) -> list[int]:
+    corpus: list[int] = []
+    for weight in range(maximum_weight + 1):
+        for support in itertools.combinations(range(n), weight):
+            corpus.append(sum(1 << index for index in support))
+    return corpus
+
+
+def classify(corpus: list[int], rows: list[int], stabilizers: set[int], table: dict[int, int]) -> dict[str, Any]:
+    success_by_weight: Counter[int] = Counter()
+    nonzero = wrong = 0
+    for error in corpus:
+        correction = table[syndrome(error, rows)]
+        residual = error ^ correction
+        if syndrome(residual, rows) != 0:
+            nonzero += 1
+        elif residual in stabilizers:
+            success_by_weight[error.bit_count()] += 1
+        else:
+            wrong += 1
+    success = sum(success_by_weight.values())
+    return {
+        "success_total": success,
+        "failure_total": len(corpus) - success,
+        "success_by_error_weight": {str(weight): success_by_weight[weight] for weight in range(5)},
+        "failure_modes": {
+            "nonzero_residual_syndrome": nonzero,
+            "zero_syndrome_wrong_logical_coset": wrong,
+        },
+    }
+
+
+def semantic_products(
+    values: dict[str, dict[int, int]], representatives: dict[int, int], class_keys: dict[int, int],
+    rows: list[int], logical_z: list[int], stabilizers: set[int],
+) -> tuple[dict[str, Any], dict[str, dict[int, int]], dict[str, dict[int, list[tuple[int, int]]]]]:
+    mapping_records: list[dict[str, Any]] = []
+    for selector in sorted(values["min_plus_hamming"]):
+        syn = selector & ((1 << len(rows)) - 1)
+        mapping_records.append({
+            "selector": i2b(selector, len(rows) + len(logical_z)),
+            "syndrome": i2b(syn, len(rows)),
+            "logical_label": i2b(selector >> len(rows), len(logical_z)),
+            "canonical_coset_key": i2b(class_keys[selector], 18),
+            "minimum_representative": i2b(representatives[selector], 18),
+            "minimum_weight": values["min_plus_hamming"][selector],
+        })
+    mapping_sha = digest(mapping_records)
+    if mapping_sha != EXPECTED_MAPPING_SHA:
+        raise AssertionError("compiled mapping identity changed")
+
+    score_sha: dict[str, str] = {}
+    for algebra in SEMIRINGS:
+        records = [{"selector": i2b(selector, 13), "score": values[algebra][selector]} for selector in sorted(values[algebra])]
+        score_sha[algebra] = digest(records)
+    if score_sha != EXPECTED_SCORE_SHA:
+        raise AssertionError("compiled score identities changed")
+
+    by_syndrome: dict[int, list[int]] = {}
+    for selector in sorted(values["min_plus_hamming"]):
+        by_syndrome.setdefault(selector & 511, []).append(selector)
+    if len(by_syndrome) != 128 or set(map(len, by_syndrome.values())) != {16}:
+        raise AssertionError("selector geometry changed")
+
+    tables: dict[str, dict[int, int]] = {algebra: {} for algebra in SEMIRINGS}
+    ties: dict[str, dict[int, list[tuple[int, int]]]] = {algebra: {} for algebra in SEMIRINGS}
+    tie_sha: dict[str, str] = {}
+    decision_sha: dict[str, str] = {}
+    for algebra in SEMIRINGS:
+        tie_records: list[dict[str, Any]] = []
+        maximize = SEMIRINGS[algebra]["score_direction"] == "maximize"
+        for syn, selectors in sorted(by_syndrome.items()):
+            scores = [values[algebra][selector] for selector in selectors]
+            best = max(scores) if maximize else min(scores)
+            tied = [selector for selector in selectors if values[algebra][selector] == best]
+            tied.sort(key=lambda item: class_keys[item])
+            choices = [(class_keys[item], representatives[item]) for item in tied]
+            ties[algebra][syn] = choices
+            tables[algebra][syn] = choices[0][1]
+            tie_records.append({
+                "syndrome": i2b(syn, 9),
+                "canonical_coset_keys": [i2b(key, 18) for key, _ in choices],
+            })
+        tie_sha[algebra] = digest(tie_records)
+        decision_records = [{"syndrome": i2b(syn, 9), "correction": i2b(correction, 18)} for syn, correction in sorted(tables[algebra].items())]
+        decision_sha[algebra] = digest(decision_records)
+    if tie_sha != EXPECTED_TIE_SHA or decision_sha != EXPECTED_DECISION_SHA:
+        raise AssertionError("compiled tie/decision identity changed")
+
+    corpus = make_corpus()
+    decisions: dict[str, Any] = {}
+    tie_report: dict[str, Any] = {}
+    by_corpus_syndrome: dict[int, list[int]] = {}
+    for error in corpus:
+        by_corpus_syndrome.setdefault(syndrome(error, rows), []).append(error)
+
+    for algebra in SEMIRINGS:
+        result = classify(corpus, rows, stabilizers, tables[algebra])
+        if result["success_total"] != EXPECTED_SUCCESS[algebra]:
+            raise AssertionError(f"success total changed: {algebra}")
+        decisions[algebra] = {**result, "decision_table_sha256": decision_sha[algebra]}
+        histogram = Counter(len(choices) for choices in ties[algebra].values())
+        minimum = maximum = 0
+        for syn, choices in ties[algebra].items():
+            errors = by_corpus_syndrome.get(syn, [])
+            successes = [sum((error ^ correction) in stabilizers for error in errors) for _, correction in choices]
+            minimum += min(successes)
+            maximum += max(successes)
+        expected = EXPECTED_TIE_ENVELOPES[algebra]
+        if [minimum, maximum] != expected:
+            raise AssertionError(f"tie envelope changed: {algebra}")
+        tie_report[algebra] = {
+            "winning_class_count_histogram": {str(key): value for key, value in sorted(histogram.items())},
+            "frozen_corpus_success_count_envelope_over_winning_class_ties": {"min": minimum, "max": maximum},
+            "default_lowest_key_success_count": result["success_total"],
+            "success_count_invariant_under_winning_class_tie_break": minimum == maximum,
+        }
+
+    semantic = {
+        "score_entries_checked": 6144,
+        "score_tables_exactly_equal": True,
+        "class_mapping_entries_checked": 2048,
+        "class_mapping_exactly_equal": True,
+        "winning_class_tie_set_cells_checked": 384,
+        "winning_class_tie_sets_exactly_equal": True,
+        "decision_entries_checked": 384,
+        "decision_tables_exactly_equal": True,
+        "score_table_sha256": score_sha,
+        "canonical_class_mapping_sha256": mapping_sha,
+        "winning_class_tie_sets_sha256": tie_sha,
+        "decision_table_sha256": decision_sha,
+        "frozen_corpus_success_totals": EXPECTED_SUCCESS,
+        "tie_envelopes": EXPECTED_TIE_ENVELOPES,
+    }
+    return {"equivalence": semantic, "decisions": decisions, "tie_sensitivity": tie_report}, tables, ties
+
+
+def add_vectors(vectors: list[dict[str, int]]) -> dict[str, int]:
+    return {kind: sum(vector[kind] for vector in vectors) for kind in AOP_TYPES}
+
+
+def evaluate_core(experiment: dict[str, Any]) -> dict[str, Any]:
+    rows, logical_z = construct_code()
+    basis_rows = [rows[index] for index in EXPECTED_STABILIZER_BASIS]
+    stabilizers = gf2_span(basis_rows)
+    if len(stabilizers) != 128:
+        raise AssertionError("stabilizer basis span changed")
+    scopes = [tuple(variable for variable, row in enumerate(basis_rows) if row & (1 << qubit)) for qubit in range(18)]
+    scope_records = [{"qubit": qubit, "stabilizer_variables": list(scopes[qubit])} for qubit in range(18)]
+    scope_sha = digest(scope_records)
+    if scope_sha != EXPECTED_SCOPE_SHA:
+        raise AssertionError("factor scope identity changed")
+    selector_columns = [combined_selector(1 << qubit, rows, logical_z) for qubit in range(18)]
+    seed_selectors: set[int] = set()
+    for coordinate in range(2048):
+        selector = 0
+        for qubit in EXPECTED_SELECTOR_BASIS:
+            if coordinate & (1 << qubit):
+                selector ^= selector_columns[qubit]
+        seed_selectors.add(selector)
+    if len(seed_selectors) != 2048:
+        raise AssertionError("selector basis lost rank")
+
+    kind_by_algebra = {
+        "sum_product_bsc_p_0_1": "sum9",
+        "soft_tropical_base_2": "sum2",
+        "min_plus_hamming": "min",
+    }
+    compiled_metadata: dict[str, Any] = {}
+    values: dict[str, dict[int, int]] = {algebra: {} for algebra in SEMIRINGS}
+    representatives: dict[int, int] = {}
+    class_keys: dict[int, int] = {}
+    evaluation_cost: dict[str, Any] = {}
+    baseline_cost: dict[str, Any] = {}
+
+    for algebra in SEMIRINGS:
+        kind = kind_by_algebra[algebra]
+        dag, root, metadata = compile_symbolic(kind, scopes)
+        compiled_metadata[algebra] = metadata
+        evaluation_ledger = Ledger()
+        evaluation_totals: list[int] = []
+        visited_counts: list[int] = []
+        for coordinate in range(2048):
+            local_ledger = Ledger()
+            result, visited = dag.evaluate(root, coordinate, local_ledger)
+            selector = selector_from_coordinate(coordinate, selector_columns, local_ledger)
+            for aop, count in local_ledger.counts.items():
+                evaluation_ledger.add(aop, count)
+            evaluation_totals.append(local_ledger.total())
+            visited_counts.append(visited)
+            if kind == "min":
+                (minimum_weight, representative), canonical = result
+                values[algebra][selector] = minimum_weight
+                representatives[selector] = representative
+                class_keys[selector] = canonical
+            else:
+                values[algebra][selector] = result
+
+        evaluation_cost[algebra] = {
+            "aop": evaluation_ledger.vector(),
+            "aop_total": evaluation_ledger.total(),
+            "per_selector_aop_min": min(evaluation_totals),
+            "per_selector_aop_max": max(evaluation_totals),
+            "per_selector_aop_mean_numerator": sum(evaluation_totals),
+            "per_selector_aop_mean_denominator": len(evaluation_totals),
+            "visited_compiled_nodes_per_selector_min": min(visited_counts),
+            "visited_compiled_nodes_per_selector_max": max(visited_counts),
+        }
+
+        baseline_ledger = Ledger()
+        for coordinate in range(2048):
+            replay = classwise_contract(coordinate, scopes, kind, baseline_ledger)
+            selector = selector_from_coordinate(coordinate, selector_columns, baseline_ledger)
+            if kind == "min":
+                (weight, representative), canonical = replay
+                if (
+                    weight != values[algebra][selector]
+                    or representative != representatives[selector]
+                    or canonical != class_keys[selector]
+                ):
+                    raise AssertionError("compiled path disagrees with classwise TCM-QDEC-003 replay")
+            elif replay != values[algebra][selector]:
+                raise AssertionError("compiled path disagrees with classwise TCM-QDEC-003 replay")
+        baseline_cost[algebra] = {"aop": baseline_ledger.vector(), "aop_total": baseline_ledger.total()}
+
+    semantic, _, _ = semantic_products(values, representatives, class_keys, rows, logical_z, stabilizers)
+
+    compile_vectors = [compiled_metadata[algebra]["compile_aop"] for algebra in SEMIRINGS]
+    eval_vectors = [evaluation_cost[algebra]["aop"] for algebra in SEMIRINGS]
+    baseline_vectors = [baseline_cost[algebra]["aop"] for algebra in SEMIRINGS]
+    compile_vector = add_vectors(compile_vectors)
+    eval_vector = add_vectors(eval_vectors)
+    baseline_vector = add_vectors(baseline_vectors)
+    compile_total = sum(compile_vector.values())
+    eval_total = sum(eval_vector.values())
+    baseline_total = sum(baseline_vector.values())
+    one_shot = compile_total + eval_total
+    reduction = baseline_total - one_shot
+    if reduction <= 0:
+        outcome = "EXACT_SHARED_COMPILATION_NO_COST_REDUCTION"
+        break_even = None
+    else:
+        outcome = "EXACT_SHARED_COMPILATION_WITH_REDUCED_DUPLICATION"
+        denominator = baseline_total - eval_total
+        break_even = (compile_total + denominator - 1) // denominator
+
+    report: dict[str, Any] = {
+        "experiment_id": "TCM-QDEC-004",
+        "evaluator_version": EVALUATOR_VERSION,
+        "status": "candidate_executable_not_promoted",
+        "predecessor": experiment["predecessor"],
+        "claim_boundary": experiment["claim_boundary"],
+        "representation": experiment["representation"],
+        "semirings": experiment["semirings"],
+        "decision_rule": experiment["decision_rule"],
+        "basis_geometry": {
+            "stabilizer_basis_row_indices": EXPECTED_STABILIZER_BASIS,
+            "stabilizer_span_size": len(stabilizers),
+            "selector_seed_basis_qubits": EXPECTED_SELECTOR_BASIS,
+            "reachable_selector_count": len(seed_selectors),
+            "factor_scope_size_histogram": {str(size): count for size, count in sorted(Counter(map(len, scopes)).items())},
+            "factor_scope_sha256": scope_sha,
+            "frozen_degeneracy_elimination_order": EXPECTED_ORDER,
+        },
+        "compiled_structure": {
+            "primary_object_is_complete_answer_cache": False,
+            "selector_values_materialized_during_compilation": 0,
+            "selector_parameters_enter_only_through_parameter_choice_nodes": True,
+            "per_algebra": compiled_metadata,
+            "retained_reachable_nodes_total": sum(compiled_metadata[a]["retained_reachable_nodes"] for a in SEMIRINGS),
+            "canonical_serialized_bytes_total": sum(compiled_metadata[a]["canonical_serialized_bytes"] for a in SEMIRINGS),
+        },
+        "semantic_equivalence": semantic["equivalence"],
+        "compiled_decisions": semantic["decisions"],
+        "tie_sensitivity": semantic["tie_sensitivity"],
+        "cost_accounting": {
+            "aop_types": AOP_TYPES,
+            "aop_total_is_runtime_model": False,
+            "runtime_or_memory_superiority_inferred": False,
+            "compile": {"aop": compile_vector, "aop_total": compile_total},
+            "evaluate_all_2048_selectors": {"aop": eval_vector, "aop_total": eval_total, "per_algebra": evaluation_cost},
+            "one_shot": {"aop_total": one_shot},
+            "tcm_qdec_003_reinstrumented_classwise_replay": {
+                "aop": baseline_vector,
+                "aop_total": baseline_total,
+                "per_algebra": baseline_cost,
+                "original_assignment_evaluations_preserved": 774144,
+                "original_predecessor_transition_relaxations_preserved": 98298,
+                "original_counters_not_translated_to_aop": True,
+            },
+            "one_shot_aop_reduction": reduction,
+            "compiled_one_shot_uses_fewer_aops": reduction > 0,
+            "repeated_complete_sweep_formula": "C_compile + k*C_eval_all versus k*C_003_all",
+            "break_even_complete_sweeps": break_even,
+        },
+        "adjudication": {
+            "outcome": outcome,
+            "exact_semantics_preserved": True,
+            "nontrivial_shared_structural_object": True,
+            "complete_answer_cache_disallowed_and_not_used": True,
+            "abstract_operation_reduction_observed": reduction > 0,
+            "runtime_superiority_claim": False,
+            "memory_superiority_claim": False,
+            "downstream_authority_created": False,
+        },
+    }
+    report["payload_sha256"] = digest(report)
+    return report
+
+
+def evaluate(
+    experiment: dict[str, Any],
+    tcm3_registry: dict[str, Any],
+    tcm3_evidence: dict[str, Any],
+    tcm3_promotion: dict[str, Any],
+) -> dict[str, Any]:
+    validate_predecessor(tcm3_registry, tcm3_evidence, tcm3_promotion)
+    return evaluate_core(experiment)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--registry", default=str(ROOT / "registry" / "tcm-qdec-004.json"))
+    parser.add_argument("--tcm-003-registry", default=str(ROOT / "registry" / "tcm-qdec-003.json"))
+    parser.add_argument("--tcm-003-evidence", default=str(ROOT / "evidence" / "TCM-QDEC-003-report.json"))
+    parser.add_argument("--tcm-003-promotion", default=str(ROOT / "reviews" / "QTR-TCM-QDEC-REVIEW-003" / "promotion-record.json"))
+    parser.add_argument("--output", default=str(ROOT / "evidence" / "TCM-QDEC-004-report.json"))
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    experiment = load_registry(Path(args.registry))
+    report = evaluate(
+        experiment,
+        load_json(Path(args.tcm_003_registry)),
+        load_json(Path(args.tcm_003_evidence)),
+        load_json(Path(args.tcm_003_promotion)),
+    )
+    output = Path(args.output)
+    if args.check:
+        if load_json(output) != report:
+            raise SystemExit("committed TCM-QDEC-004 evidence does not exactly replay")
+    else:
+        output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/registry/tcm-qdec-004.json
+++ b/registry/tcm-qdec-004.json
@@ -1,0 +1,127 @@
+{
+  "experiments": [
+    {
+      "claim_boundary": {
+        "abstract_operation_reduction_claim_only": true,
+        "adaptive_online_contraction_order_authorized": false,
+        "asymptotic_complexity_claim": false,
+        "autonomous_search_authorized": false,
+        "bounded_width_family_claim": false,
+        "bp_min_sum_bp_osd_comparison_authorized": false,
+        "circuit_level_noise_authorized": false,
+        "exact_predecessor_semantics_required": true,
+        "exact_shared_compilation_on_fixed_fixture_only": true,
+        "larger_code_authorized": false,
+        "learned_decoder_authorized": false,
+        "memory_superiority_claim": false,
+        "multi_size_scaling_authorized": false,
+        "qldpc_forge_authorized": false,
+        "repeated_syndrome_authorized": false,
+        "runtime_superiority_claim": false,
+        "selector_answer_cache_primary_object_allowed": false
+      },
+      "decision_rule": {
+        "class_tie_break": "lowest_canonical_stabilizer_coset_key",
+        "representative_within_class": "lowest_hamming_weight_then_integer",
+        "winning_class": "exact_semiring_optimum"
+      },
+      "experiment_id": "TCM-QDEC-004",
+      "predecessor": {
+        "evidence_path": "evidence/TCM-QDEC-003-report.json",
+        "evidence_payload_sha256": "f0ecdae04f3da4f0508454da59ce406a4e6c461f88f1784279cb6d7e360b595f",
+        "experiment_id": "TCM-QDEC-003",
+        "promotion_main_commit": "4524be6fd51eb78b627e4303cd713b5c215fc7a8",
+        "promotion_record_path": "reviews/QTR-TCM-QDEC-REVIEW-003/promotion-record.json",
+        "registry_path": "registry/tcm-qdec-003.json",
+        "reviewed_head": "968029c156a3d668a0adc9adce850b62cd249671",
+        "scientific_merge_commit": "2925a41343c8e4592c1bf558d86ea461e0e1c7d4"
+      },
+      "programme": "QTR",
+      "representation": {
+        "anti_cache_rule": "complete_selector_answer_tables_are_not_admissible_primary_compiled_objects",
+        "canonicalization": "hash_cons_exact_expression_nodes_with_commutative_binary_operand_order",
+        "compile_policy": "symbolically_eliminate_z_keep_a_explicit",
+        "frozen_degeneracy_elimination_order": [
+          2,
+          4,
+          0,
+          1,
+          3,
+          5,
+          6
+        ],
+        "kind": "exact_selector_parametric_hash_consed_expression_dag",
+        "operation_taxonomy": [
+          "GF2_XOR",
+          "GF2_AND",
+          "EXACT_INT_ADD",
+          "EXACT_INT_MUL",
+          "EXACT_COMPARE",
+          "TABLE_READ",
+          "TABLE_WRITE",
+          "NODE_INTERN"
+        ],
+        "parameter_interface": "eleven_boolean_selector_coordinates",
+        "physical_variable_count": 18,
+        "primary_full_physical_state_enumeration": false,
+        "primary_full_selector_enumeration_during_compilation": false,
+        "reachable_selector_count": 2048,
+        "selector_parameter_count": 11,
+        "selector_seed_basis_qubits": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        "stabilizer_basis_row_indices": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "stabilizer_generator_count": 7
+      },
+      "semirings": {
+        "min_plus_hamming": {
+          "interpretation": "minimum Hamming-weight tropical score",
+          "kind": "min_plus",
+          "local_bit_costs": [
+            0,
+            1
+          ],
+          "score_direction": "minimize"
+        },
+        "soft_tropical_base_2": {
+          "interpretation": "exact partition score equivalent in ranking to beta=ln(2) soft-min",
+          "kind": "soft_tropical",
+          "local_bit_weights": [
+            2,
+            1
+          ],
+          "score_direction": "maximize"
+        },
+        "sum_product_bsc_p_0_1": {
+          "interpretation": "exact numerator proportional to BSC p=0.1 likelihood",
+          "kind": "sum_product",
+          "local_bit_weights": [
+            9,
+            1
+          ],
+          "score_direction": "maximize"
+        }
+      },
+      "status": "candidate_executable_not_promoted"
+    }
+  ],
+  "registry_version": "0.1.0"
+}

--- a/tests/test_tcm_qdec_004.py
+++ b/tests/test_tcm_qdec_004.py
@@ -1,0 +1,206 @@
+import copy
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "reference" / "tcm_qdec_004.py"
+SPEC = importlib.util.spec_from_file_location("tcm_qdec_004", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+class TCMQDEC004Tests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.registry_path = ROOT / "registry" / "tcm-qdec-004.json"
+        cls.tcm3_registry = json.loads((ROOT / "registry" / "tcm-qdec-003.json").read_text())
+        cls.tcm3_evidence = json.loads((ROOT / "evidence" / "TCM-QDEC-003-report.json").read_text())
+        cls.tcm3_promotion = json.loads(
+            (ROOT / "reviews" / "QTR-TCM-QDEC-REVIEW-003" / "promotion-record.json").read_text()
+        )
+        cls.experiment = MODULE.load_registry(cls.registry_path)
+        cls.report = MODULE.evaluate(
+            cls.experiment, cls.tcm3_registry, cls.tcm3_evidence, cls.tcm3_promotion
+        )
+
+    def test_committed_evidence_exactly_replays(self):
+        expected = json.loads((ROOT / "evidence" / "TCM-QDEC-004-report.json").read_text())
+        self.assertEqual(self.report, expected)
+        self.assertEqual(
+            self.report["payload_sha256"],
+            "a5c7e59fa849ddc37c070d78d4a4dab8b07ae5ceccfecefeb5a20f4ae0dc83a7",
+        )
+
+    def test_compiled_object_is_structural_not_answer_cache(self):
+        compiled = self.report["compiled_structure"]
+        self.assertFalse(compiled["primary_object_is_complete_answer_cache"])
+        self.assertEqual(compiled["selector_values_materialized_during_compilation"], 0)
+        self.assertTrue(compiled["selector_parameters_enter_only_through_parameter_choice_nodes"])
+        self.assertEqual(compiled["retained_reachable_nodes_total"], 1130)
+        self.assertEqual(compiled["canonical_serialized_bytes_total"], 65506)
+        expected = {
+            "sum_product_bsc_p_0_1": (371, "74a20187b141813772400944962462b0fd4859f253b161bedc3d871231cfad8e"),
+            "soft_tropical_base_2": (371, "e15b58e494d5ff75efd8778210d1d195701e71dea84a8d8dff4eafe02dcf2d68"),
+            "min_plus_hamming": (388, "daaa544340d1d101c402f0f7be0d95eaf75c8f861fe7018f12cf29a797b35339"),
+        }
+        for algebra, (nodes, sha) in expected.items():
+            cell = compiled["per_algebra"][algebra]
+            self.assertEqual(cell["retained_reachable_nodes"], nodes)
+            self.assertEqual(cell["canonical_sha256"], sha)
+            self.assertLess(nodes, 2048)
+            self.assertGreater(cell["hash_cons_reuses"], 0)
+
+    def test_full_predecessor_semantic_boundary_is_exact(self):
+        exact = self.report["semantic_equivalence"]
+        self.assertEqual(exact["score_entries_checked"], 6144)
+        self.assertEqual(exact["class_mapping_entries_checked"], 2048)
+        self.assertEqual(exact["winning_class_tie_set_cells_checked"], 384)
+        self.assertEqual(exact["decision_entries_checked"], 384)
+        self.assertTrue(exact["score_tables_exactly_equal"])
+        self.assertTrue(exact["class_mapping_exactly_equal"])
+        self.assertTrue(exact["winning_class_tie_sets_exactly_equal"])
+        self.assertTrue(exact["decision_tables_exactly_equal"])
+        self.assertEqual(exact["score_table_sha256"], MODULE.EXPECTED_SCORE_SHA)
+        self.assertEqual(exact["canonical_class_mapping_sha256"], MODULE.EXPECTED_MAPPING_SHA)
+        self.assertEqual(exact["winning_class_tie_sets_sha256"], MODULE.EXPECTED_TIE_SHA)
+        self.assertEqual(exact["decision_table_sha256"], MODULE.EXPECTED_DECISION_SHA)
+
+    def test_min_plus_tie_ambiguity_is_retained(self):
+        tie = self.report["tie_sensitivity"]["min_plus_hamming"]
+        self.assertEqual(
+            tie["frozen_corpus_success_count_envelope_over_winning_class_ties"],
+            {"min": 218, "max": 263},
+        )
+        self.assertEqual(tie["default_lowest_key_success_count"], 226)
+        self.assertFalse(tie["success_count_invariant_under_winning_class_tie_break"])
+
+    def test_common_aop_accounting_is_exact_and_positive(self):
+        cost = self.report["cost_accounting"]
+        self.assertEqual(cost["aop_types"], MODULE.AOP_TYPES)
+        self.assertEqual(cost["compile"]["aop_total"], 10160)
+        self.assertEqual(cost["evaluate_all_2048_selectors"]["aop_total"], 12694528)
+        self.assertEqual(cost["one_shot"]["aop_total"], 12704688)
+        self.assertEqual(
+            cost["tcm_qdec_003_reinstrumented_classwise_replay"]["aop_total"],
+            14115840,
+        )
+        self.assertEqual(cost["one_shot_aop_reduction"], 1411152)
+        self.assertTrue(cost["compiled_one_shot_uses_fewer_aops"])
+        self.assertEqual(cost["break_even_complete_sweeps"], 1)
+        self.assertFalse(cost["aop_total_is_runtime_model"])
+        self.assertFalse(cost["runtime_or_memory_superiority_inferred"])
+
+    def test_original_non_equivalent_counters_are_preserved(self):
+        replay = self.report["cost_accounting"]["tcm_qdec_003_reinstrumented_classwise_replay"]
+        self.assertEqual(replay["original_assignment_evaluations_preserved"], 774144)
+        self.assertEqual(replay["original_predecessor_transition_relaxations_preserved"], 98298)
+        self.assertTrue(replay["original_counters_not_translated_to_aop"])
+
+    def test_adjudication_is_bounded_positive_result(self):
+        result = self.report["adjudication"]
+        self.assertEqual(result["outcome"], "EXACT_SHARED_COMPILATION_WITH_REDUCED_DUPLICATION")
+        self.assertTrue(result["exact_semantics_preserved"])
+        self.assertTrue(result["nontrivial_shared_structural_object"])
+        self.assertTrue(result["complete_answer_cache_disallowed_and_not_used"])
+        self.assertTrue(result["abstract_operation_reduction_observed"])
+        self.assertFalse(result["runtime_superiority_claim"])
+        self.assertFalse(result["memory_superiority_claim"])
+        self.assertFalse(result["downstream_authority_created"])
+
+    def test_downstream_claim_boundary_remains_closed(self):
+        boundary = self.report["claim_boundary"]
+        self.assertTrue(boundary["exact_shared_compilation_on_fixed_fixture_only"])
+        self.assertFalse(boundary["runtime_superiority_claim"])
+        self.assertFalse(boundary["memory_superiority_claim"])
+        self.assertFalse(boundary["asymptotic_complexity_claim"])
+        self.assertFalse(boundary["bounded_width_family_claim"])
+        self.assertFalse(boundary["larger_code_authorized"])
+        self.assertFalse(boundary["multi_size_scaling_authorized"])
+        self.assertFalse(boundary["bp_min_sum_bp_osd_comparison_authorized"])
+        self.assertFalse(boundary["circuit_level_noise_authorized"])
+        self.assertFalse(boundary["qldpc_forge_authorized"])
+
+    def test_repeated_evaluation_does_not_recompile(self):
+        rows, _ = MODULE.construct_code()
+        scopes = [
+            tuple(variable for variable, row in enumerate(rows[:7]) if row & (1 << qubit))
+            for qubit in range(18)
+        ]
+        dag, root, metadata = MODULE.compile_symbolic("sum9", scopes)
+        node_count = len(dag.nodes)
+        compile_vector = dict(dag.ledger.vector())
+        first = MODULE.Ledger()
+        second = MODULE.Ledger()
+        value_a, _ = dag.evaluate(root, 0, first)
+        value_b, _ = dag.evaluate(root, 1, second)
+        self.assertNotEqual(value_a, value_b)
+        self.assertEqual(len(dag.nodes), node_count)
+        self.assertEqual(dag.ledger.vector(), compile_vector)
+        self.assertEqual(metadata["retained_reachable_nodes"], 371)
+
+    def test_compiled_object_tamper_changes_digest(self):
+        rows, _ = MODULE.construct_code()
+        scopes = [
+            tuple(variable for variable, row in enumerate(rows[:7]) if row & (1 << qubit))
+            for qubit in range(18)
+        ]
+        dag, root, metadata = MODULE.compile_symbolic("sum9", scopes)
+        obj = dag.canonical_object(root)
+        tampered = copy.deepcopy(obj)
+        tampered["nodes"][0]["value"] = 123456
+        self.assertEqual(MODULE.digest(obj), metadata["canonical_sha256"])
+        self.assertNotEqual(MODULE.digest(tampered), metadata["canonical_sha256"])
+
+    def _mutated_registry_must_fail(self, mutation):
+        registry = json.loads(self.registry_path.read_text())
+        mutation(registry["experiments"][0])
+        path = ROOT / "tests" / ".tmp-tcm-qdec-004-registry.json"
+        try:
+            path.write_text(json.dumps(registry))
+            with self.assertRaises(ValueError):
+                MODULE.load_registry(path)
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_registry_predecessor_drift_fails_closed(self):
+        self._mutated_registry_must_fail(
+            lambda e: e["predecessor"].__setitem__("evidence_payload_sha256", "0" * 64)
+        )
+
+    def test_registry_ant_cache_drift_fails_closed(self):
+        self._mutated_registry_must_fail(
+            lambda e: e["representation"].__setitem__(
+                "anti_cache_rule", "complete_answer_cache_is_allowed"
+            )
+        )
+
+    def test_registry_operation_taxonomy_drift_fails_closed(self):
+        self._mutated_registry_must_fail(
+            lambda e: e["representation"].__setitem__(
+                "operation_taxonomy", e["representation"]["operation_taxonomy"][:-1]
+            )
+        )
+
+    def test_registry_downstream_authority_drift_fails_closed(self):
+        self._mutated_registry_must_fail(
+            lambda e: e["claim_boundary"].__setitem__("larger_code_authorized", True)
+        )
+
+    def test_tcm_003_evidence_tamper_fails_closed(self):
+        evidence = copy.deepcopy(self.tcm3_evidence)
+        evidence["payload_sha256"] = "0" * 64
+        with self.assertRaises(ValueError):
+            MODULE.validate_predecessor(self.tcm3_registry, evidence, self.tcm3_promotion)
+
+    def test_tcm_003_promotion_tamper_fails_closed(self):
+        promotion = copy.deepcopy(self.tcm3_promotion)
+        promotion["status"] = "candidate_executable_not_promoted"
+        with self.assertRaises(ValueError):
+            MODULE.validate_predecessor(self.tcm3_registry, self.tcm3_evidence, promotion)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/work-packages/QTR-TCM-QDEC-004.md
+++ b/work-packages/QTR-TCM-QDEC-004.md
@@ -1,0 +1,77 @@
+# QTR-TCM-QDEC-004 — shared exact selector-parametric compilation
+
+## Status
+
+Candidate executable, not promoted. This work package is bounded by Human Steward disposition in issue #52 comment `5311144666` and execution docket #53.
+
+## Scientific question
+
+Can the exact selector-parameterized quotient contraction be compiled once into a reusable selector-independent structural object and then evaluated across all 2048 reachable selectors with less duplicated deterministic work, while preserving the complete promoted score, mapping, tie and decision semantics?
+
+## Frozen substrate
+
+The experiment changes only evaluation architecture. It freezes the protected `[[18,4,4]]` one-sector code, source logical basis, stabilizer basis rows `[0,1,2,3,4,5,6]`, selector seed basis qubits `[0,1,2,3,4,5,6,7,8,9,10]`, seven-variable elimination order `[2,4,0,1,3,5,6]`, all three exact algebras, canonical-class and minimum-representative rules, class tie rule, and every protected TCM-QDEC-003 semantic digest.
+
+## Primary mechanism
+
+Write the promoted affine physical error as
+
+`e(a,z) = L a XOR S z`,
+
+with eleven selector parameters `a` and seven stabilizer-degeneracy variables `z`.
+
+For each local qubit factor, the evaluator constructs an exact symbolic expression depending on its stabilizer scope and, for the first eleven physical unit-basis sites, at most one selector parameter. It then eliminates the seven `z` variables in the frozen TCM-QDEC-003 order while leaving all selector parameters symbolic.
+
+The result is a canonical hash-consed expression DAG for each algebra. The DAG contains exact terminals, selector-parameter choice nodes, and exact semiring operation nodes. Compilation does not enumerate or store the 2048 evaluated selector answers. Selector coordinates enter only when the already-compiled DAG is evaluated.
+
+A complete answer table is prohibited as the primary compiled object. Such a cache is not needed by the candidate mechanism.
+
+## Exact semantic obligations
+
+Admission requires exact equality with TCM-QDEC-003 at the complete certified boundary:
+
+- 6144 class-score entries;
+- 2048 canonical-class/minimum-representative entries;
+- 384 winning-class tie sets;
+- 384 deterministic decisions;
+- frozen-corpus success totals `263`, `262`, `226`;
+- tie envelopes `[263,263]`, `[262,262]`, `[218,263]`.
+
+The committed evidence must replay from source and remain byte-for-byte deterministic under canonical JSON serialization.
+
+## Predeclared abstract-operation accounting
+
+Both the compiled path and an independently re-instrumented TCM-QDEC-003 classwise replay use the same typed AOP ledger:
+
+`GF2_XOR`, `GF2_AND`, `EXACT_INT_ADD`, `EXACT_INT_MUL`, `EXACT_COMPARE`, `TABLE_READ`, `TABLE_WRITE`, `NODE_INTERN`.
+
+The unweighted AOP sum is a deterministic abstract event count only. It is not a runtime model. No runtime or memory superiority may be inferred from it.
+
+Compilation cost, canonical compiled size, all-selector evaluation cost, one-shot cost, repeated-sweep break-even, and the original predecessor-specific counters are reported separately. The original `774144` assignment evaluations and `98298` TCM-QDEC-002 transition relaxations remain non-equivalent historical counters and are not translated into AOPs.
+
+## Candidate result
+
+The exact candidate compilation retains:
+
+- sum-product: 371 reachable expression nodes;
+- soft-tropical: 371 reachable expression nodes;
+- min-plus/product objective: 388 reachable expression nodes;
+- 1130 reachable nodes total;
+- 65,506 canonical serialized bytes total.
+
+No selector answer is materialized during compilation.
+
+The common-ledger counts are:
+
+- compilation: 10,160 AOPs;
+- evaluation of all 2048 selectors in all three algebras: 12,694,528 AOPs;
+- complete one-shot compiled path: 12,704,688 AOPs;
+- re-instrumented TCM-QDEC-003 classwise replay: 14,115,840 AOPs;
+- one-shot reduction: 1,411,152 AOPs;
+- exact complete-sweep break-even: `k = 1`.
+
+This supports only the bounded classification `EXACT_SHARED_COMPILATION_WITH_REDUCED_DUPLICATION` under the declared abstract ledger on this fixed fixture. It does not establish runtime speedup, memory superiority, asymptotic improvement, or family-scale behavior.
+
+## Fail-closed boundary
+
+No authority is created for a larger code, a multi-size scaling ladder, BP/min-sum/BP-OSD comparison, repeated syndrome extraction, measurement error, circuit-level noise, thresholds, learned decoding, adaptive online contraction order, QLDPC-FORGE, or autonomous architecture search.


### PR DESCRIPTION
## Scope

Implements issue #53 only: `TCM-QDEC-004 — shared exact selector-parametric compilation`.

Exact scientific head at opening: `8177a57b63e3f2c953a028691d305563f298b572`.
Protected base: `4524be6fd51eb78b627e4303cd713b5c215fc7a8`.
Human Steward authority: issue #52 comment `5311144666`.

The delta is exactly five additive scientific files and modifies no predecessor object.

## Scientific result

The candidate compiles the exact seven-variable stabilizer-degeneracy contraction while retaining the eleven selector coordinates as parameters. The primary artifact is a canonical hash-consed exact expression DAG, not a table of evaluated selector answers.

Candidate exact result:
- all 6144 score entries exactly preserved;
- all 2048 mapping/minimum-representative entries exactly preserved;
- all 384 tied-winning-class sets exactly preserved;
- all 384 deterministic decisions exactly preserved;
- frozen success totals remain 263 / 262 / 226;
- min-plus tie envelope remains [218,263];
- retained expression nodes: 371 / 371 / 388;
- total canonical compiled bytes: 65,506;
- compiled one-shot AOP total: 12,704,688;
- independently re-instrumented TCM-QDEC-003 classwise AOP total: 14,115,840;
- one-shot difference under the declared common unweighted AOP ledger: 1,411,152 fewer events;
- exact complete-sweep break-even: k=1.

Evidence payload: `a5c7e59fa849ddc37c070d78d4a4dab8b07ae5ceccfecefeb5a20f4ae0dc83a7`.

## Claim boundary

The AOP count is an abstract deterministic event ledger, not a runtime model. This PR makes no runtime, memory, asymptotic, family-scale, larger-code, BP/min-sum/BP-OSD, circuit-level, threshold, learned-decoder, adaptive-order, Forge, or autonomous-search claim.

A complete selector-answer cache is explicitly prohibited as the primary compiled object.

## Governance

Fail closed. Require fresh exact-head repository replay, adversarial tests, CodeQL, role-separated exact-head review, Referee disposition, and expected-head merge. Promotion, if justified, must occur through a separate documentary overlay that does not mutate the scientific registry or evidence snapshot.