### PR TITLE
QTR-COLAB-COMPUTE-001 — prepare hosted CPU/GPU/TPU experimental runner

### DIFF
--- a/colab/qtr_remote_job.py
+++ b/colab/qtr_remote_job.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import traceback
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+CONTENT = Path("/content")
+PAYLOAD = CONTENT / "gcl_source.tar.gz"
+JOB_PATH = CONTENT / "gcl_job.json"
+MANIFEST_PATH = CONTENT / "gcl_manifest.json"
+WORK_ROOT = CONTENT / "qtr_colab_work"
+SOURCE_ROOT = WORK_ROOT / "source"
+RESULT_PATH = CONTENT / "gcl_result.json"
+RECEIPT_PATH = CONTENT / "experiment_receipt.json"
+BUNDLE_PATH = CONTENT / "gcl_output_bundle.tar.gz"
+STDOUT_PATH = CONTENT / "qtr_job_stdout.txt"
+STDERR_PATH = CONTENT / "qtr_job_stderr.txt"
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def safe_extract(archive: Path, dest: Path) -> None:
+    dest.mkdir(parents=True, exist_ok=True)
+    base = dest.resolve()
+    with tarfile.open(archive, "r:gz") as tf:
+        for member in tf.getmembers():
+            target = (dest / member.name).resolve()
+            if target != base and base not in target.parents:
+                raise RuntimeError(f"unsafe archive member: {member.name}")
+            if member.issym() or member.islnk():
+                raise RuntimeError(f"links are not permitted in source payload: {member.name}")
+        tf.extractall(dest, filter="data")
+
+
+def verify_payload(manifest: dict[str, Any]) -> None:
+    if sha256_file(PAYLOAD) != manifest["payload_sha256"]:
+        raise RuntimeError("source payload digest mismatch")
+    expected = {row["path"]: row for row in manifest["files"]}
+    observed = {}
+    for path in SOURCE_ROOT.rglob("*"):
+        if path.is_file():
+            rel = path.relative_to(SOURCE_ROOT).as_posix()
+            observed[rel] = {
+                "bytes": path.stat().st_size,
+                "sha256": sha256_file(path),
+            }
+    if set(observed) != set(expected):
+        raise RuntimeError("source payload file-set mismatch")
+    for rel, row in expected.items():
+        if observed[rel]["bytes"] != row["bytes"] or observed[rel]["sha256"] != row["sha256"]:
+            raise RuntimeError(f"source payload file drift: {rel}")
+
+
+def run_command(argv: list[str]) -> int:
+    with STDOUT_PATH.open("w", encoding="utf-8") as out, STDERR_PATH.open(
+        "w", encoding="utf-8"
+    ) as err:
+        proc = subprocess.run(
+            argv,
+            cwd=SOURCE_ROOT,
+            stdout=out,
+            stderr=err,
+            text=True,
+            check=False,
+        )
+    return proc.returncode
+
+
+def make_bundle() -> None:
+    with tarfile.open(BUNDLE_PATH, "w:gz") as tf:
+        for path in (RESULT_PATH, RECEIPT_PATH, STDOUT_PATH, STDERR_PATH, MANIFEST_PATH, JOB_PATH):
+            if path.exists():
+                tf.add(path, arcname=path.name)
+
+
+def main() -> int:
+    started = datetime.now(timezone.utc).isoformat()
+    job: dict[str, Any] = {}
+    manifest: dict[str, Any] = {}
+    runtime: dict[str, Any] = {}
+    status = "RED_ENGINEERING"
+    returncode = 99
+    fatal_error = None
+    try:
+        job = json.loads(JOB_PATH.read_text(encoding="utf-8"))
+        manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+        if WORK_ROOT.exists():
+            shutil.rmtree(WORK_ROOT)
+        safe_extract(PAYLOAD, SOURCE_ROOT)
+        verify_payload(manifest)
+
+        sys.path.insert(0, str(SOURCE_ROOT / "reference"))
+        from qtr_colab_runtime_probe import (
+            detect_runtime,
+            validate_job,
+            validate_requested_runtime,
+        )
+
+        validate_job(job)
+        runtime = detect_runtime()
+        validate_requested_runtime(job, runtime)
+
+        workload = job["workload"]
+        if workload == "runtime_probe":
+            argv = [
+                sys.executable,
+                str(SOURCE_ROOT / "reference/qtr_colab_runtime_probe.py"),
+                "--job",
+                str(JOB_PATH),
+                "--output",
+                str(RESULT_PATH),
+            ]
+        elif workload == "compute_requal_preflight":
+            if job["scientific_backend"] != "cpu_reference":
+                raise RuntimeError("compute requalification preflight is bound to cpu_reference")
+            argv = [
+                sys.executable,
+                str(SOURCE_ROOT / "reference/qtr_compute_requal_001.py"),
+                "--job",
+                str(JOB_PATH),
+                "--output",
+                str(RESULT_PATH),
+            ]
+        elif workload == "c90_exact_candidate":
+            raise RuntimeError(
+                "C90 exact candidate is intentionally disabled in QTR-COLAB-COMPUTE-001; "
+                "separate scientific execution authority is required"
+            )
+        else:
+            raise RuntimeError(f"unsupported workload: {workload}")
+
+        returncode = run_command(argv)
+        if returncode != 0:
+            raise RuntimeError(f"workload exited with code {returncode}")
+        result = json.loads(RESULT_PATH.read_text(encoding="utf-8"))
+        if not str(result.get("status", "")).startswith("GREEN_ENGINEERING"):
+            raise RuntimeError(f"unexpected workload status: {result.get('status')}")
+        status = "GREEN_ENGINEERING"
+        returncode = 0
+    except Exception as exc:
+        fatal_error = f"{type(exc).__name__}: {exc}"
+        STDERR_PATH.write_text(
+            (STDERR_PATH.read_text(encoding="utf-8") if STDERR_PATH.exists() else "")
+            + "\n"
+            + traceback.format_exc(),
+            encoding="utf-8",
+        )
+    finally:
+        receipt = {
+            "schema_version": 1,
+            "experiment_id": job.get("experiment_id"),
+            "status": status,
+            "started_at": started,
+            "finished_at": datetime.now(timezone.utc).isoformat(),
+            "source_commit": manifest.get("source_commit"),
+            "source_payload_sha256": manifest.get("payload_sha256"),
+            "job_sha256": sha256_file(JOB_PATH) if JOB_PATH.exists() else None,
+            "result_sha256": sha256_file(RESULT_PATH) if RESULT_PATH.exists() else None,
+            "runtime": runtime,
+            "workload": job.get("workload"),
+            "scientific_backend": job.get("scientific_backend"),
+            "scientific_execution_authorized": job.get("scientific_execution_authorized", False),
+            "promotion_claim": False,
+            "fatal_error": fatal_error,
+            "returncode": returncode,
+            "claim_boundary": job.get("claim_boundary"),
+        }
+        RECEIPT_PATH.write_text(
+            json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        make_bundle()
+    return returncode if status == "GREEN_ENGINEERING" else max(1, returncode)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/configs/compute/qtr_c90_exact_candidate_matrix.json
+++ b/configs/compute/qtr_c90_exact_candidate_matrix.json
@@ -1,0 +1,49 @@
+{
+  "claim_boundary": {
+    "c90_exact_compilation_authorized": false,
+    "engineering_evidence_only": true,
+    "hardware_performance_claim": false,
+    "physical_materialization_authorized": false,
+    "promotion_authorized": false,
+    "qec_circuit_003_authorized": false,
+    "qldpc_forge_authorized": false,
+    "runtime_or_memory_superiority_claim": false,
+    "scientific_execution_authorized": false,
+    "selector_validation_authorized": false
+  },
+  "jobs": [
+    {
+      "claim_boundary": {
+        "c90_exact_compilation_authorized": false,
+        "engineering_evidence_only": true,
+        "hardware_performance_claim": false,
+        "physical_materialization_authorized": false,
+        "promotion_authorized": false,
+        "qec_circuit_003_authorized": false,
+        "qldpc_forge_authorized": false,
+        "runtime_or_memory_superiority_claim": false,
+        "scientific_execution_authorized": false,
+        "selector_validation_authorized": false
+      },
+      "enabled": false,
+      "experiment_id": "QTR-C90-EXACT-REQUAL-CANDIDATE-001",
+      "nominal_envelope_multiplier": 100,
+      "remote_timeout_seconds": 21600,
+      "required_authorization": {
+        "requirement": "separate QTR scientific execution contract and Human Steward authorization after runtime/memory prequalification",
+        "status": "UNSATISFIED"
+      },
+      "resource": {
+        "accelerator": null,
+        "variant": "CPU"
+      },
+      "schema_version": 1,
+      "scientific_backend": "cpu_reference",
+      "scientific_execution_authorized": false,
+      "workload": "c90_exact_candidate"
+    }
+  ],
+  "matrix_id": "QTR-C90-EXACT-REQUAL-CANDIDATE-001",
+  "schema_version": 1,
+  "status": "FROZEN_DISABLED_PENDING_SEPARATE_SCIENTIFIC_AUTHORITY"
+}

--- a/configs/compute/qtr_colab_runtime_probe_matrix.json
+++ b/configs/compute/qtr_colab_runtime_probe_matrix.json
@@ -1,0 +1,148 @@
+{
+  "claim_boundary": {
+    "engineering_evidence_only": true,
+    "hardware_performance_claim": false,
+    "promotion_authorized": false,
+    "qec_circuit_003_authorized": false,
+    "qldpc_forge_authorized": false,
+    "runtime_or_memory_superiority_claim": false,
+    "scientific_execution_authorized": false
+  },
+  "jobs": [
+    {
+      "claim_boundary": {
+        "engineering_evidence_only": true,
+        "hardware_performance_claim": false,
+        "promotion_authorized": false,
+        "qec_circuit_003_authorized": false,
+        "qldpc_forge_authorized": false,
+        "runtime_or_memory_superiority_claim": false,
+        "scientific_execution_authorized": false
+      },
+      "enabled": true,
+      "experiment_id": "QTR-COLAB-RUNTIME-PROBE-001-CPU",
+      "remote_timeout_seconds": 1200,
+      "resource": {
+        "accelerator": null,
+        "variant": "CPU"
+      },
+      "schema_version": 1,
+      "scientific_backend": "engineering_probe",
+      "scientific_execution_authorized": false,
+      "workload": "runtime_probe"
+    },
+    {
+      "claim_boundary": {
+        "engineering_evidence_only": true,
+        "hardware_performance_claim": false,
+        "promotion_authorized": false,
+        "qec_circuit_003_authorized": false,
+        "qldpc_forge_authorized": false,
+        "runtime_or_memory_superiority_claim": false,
+        "scientific_execution_authorized": false
+      },
+      "enabled": true,
+      "experiment_id": "QTR-COLAB-RUNTIME-PROBE-001-T4",
+      "remote_timeout_seconds": 1200,
+      "resource": {
+        "accelerator": "T4",
+        "variant": "GPU"
+      },
+      "schema_version": 1,
+      "scientific_backend": "engineering_probe",
+      "scientific_execution_authorized": false,
+      "workload": "runtime_probe"
+    },
+    {
+      "claim_boundary": {
+        "engineering_evidence_only": true,
+        "hardware_performance_claim": false,
+        "promotion_authorized": false,
+        "qec_circuit_003_authorized": false,
+        "qldpc_forge_authorized": false,
+        "runtime_or_memory_superiority_claim": false,
+        "scientific_execution_authorized": false
+      },
+      "enabled": true,
+      "experiment_id": "QTR-COLAB-RUNTIME-PROBE-001-L4",
+      "remote_timeout_seconds": 1200,
+      "resource": {
+        "accelerator": "L4",
+        "variant": "GPU"
+      },
+      "schema_version": 1,
+      "scientific_backend": "engineering_probe",
+      "scientific_execution_authorized": false,
+      "workload": "runtime_probe"
+    },
+    {
+      "claim_boundary": {
+        "engineering_evidence_only": true,
+        "hardware_performance_claim": false,
+        "promotion_authorized": false,
+        "qec_circuit_003_authorized": false,
+        "qldpc_forge_authorized": false,
+        "runtime_or_memory_superiority_claim": false,
+        "scientific_execution_authorized": false
+      },
+      "enabled": true,
+      "experiment_id": "QTR-COLAB-RUNTIME-PROBE-001-A100",
+      "remote_timeout_seconds": 1200,
+      "resource": {
+        "accelerator": "A100",
+        "variant": "GPU"
+      },
+      "schema_version": 1,
+      "scientific_backend": "engineering_probe",
+      "scientific_execution_authorized": false,
+      "workload": "runtime_probe"
+    },
+    {
+      "claim_boundary": {
+        "engineering_evidence_only": true,
+        "hardware_performance_claim": false,
+        "promotion_authorized": false,
+        "qec_circuit_003_authorized": false,
+        "qldpc_forge_authorized": false,
+        "runtime_or_memory_superiority_claim": false,
+        "scientific_execution_authorized": false
+      },
+      "enabled": true,
+      "experiment_id": "QTR-COLAB-RUNTIME-PROBE-001-TPU-V5E1",
+      "remote_timeout_seconds": 1200,
+      "resource": {
+        "accelerator": "v5e1",
+        "variant": "TPU"
+      },
+      "schema_version": 1,
+      "scientific_backend": "engineering_probe",
+      "scientific_execution_authorized": false,
+      "workload": "runtime_probe"
+    },
+    {
+      "claim_boundary": {
+        "engineering_evidence_only": true,
+        "hardware_performance_claim": false,
+        "promotion_authorized": false,
+        "qec_circuit_003_authorized": false,
+        "qldpc_forge_authorized": false,
+        "runtime_or_memory_superiority_claim": false,
+        "scientific_execution_authorized": false
+      },
+      "enabled": true,
+      "experiment_id": "QTR-COLAB-RUNTIME-PROBE-001-TPU-V6E1",
+      "remote_timeout_seconds": 1200,
+      "resource": {
+        "accelerator": "v6e1",
+        "variant": "TPU"
+      },
+      "schema_version": 1,
+      "scientific_backend": "engineering_probe",
+      "scientific_execution_authorized": false,
+      "workload": "runtime_probe"
+    }
+  ],
+  "matrix_id": "QTR-COLAB-RUNTIME-PROBE-001",
+  "schema_version": 1,
+  "status": "ENGINEERING_PROBE_ONLY"
+}

--- a/configs/compute/qtr_compute_requal_001_matrix.json
+++ b/configs/compute/qtr_compute_requal_001_matrix.json
@@ -1,0 +1,45 @@
+{
+  "claim_boundary": {
+    "changes_protected_scientific_result": false,
+    "engineering_evidence_only": true,
+    "entry_count_requalification_only": true,
+    "hardware_performance_claim": false,
+    "physical_materialization_authorized": false,
+    "promotion_authorized": false,
+    "qec_circuit_003_authorized": false,
+    "qldpc_forge_authorized": false,
+    "runtime_or_memory_superiority_claim": false,
+    "scientific_execution_authorized": false
+  },
+  "jobs": [
+    {
+      "claim_boundary": {
+        "changes_protected_scientific_result": false,
+        "engineering_evidence_only": true,
+        "entry_count_requalification_only": true,
+        "hardware_performance_claim": false,
+        "physical_materialization_authorized": false,
+        "promotion_authorized": false,
+        "qec_circuit_003_authorized": false,
+        "qldpc_forge_authorized": false,
+        "runtime_or_memory_superiority_claim": false,
+        "scientific_execution_authorized": false
+      },
+      "enabled": true,
+      "experiment_id": "QTR-COMPUTE-REQUAL-001-PREFLIGHT-CPU",
+      "nominal_envelope_multiplier": 100,
+      "remote_timeout_seconds": 3600,
+      "resource": {
+        "accelerator": null,
+        "variant": "CPU"
+      },
+      "schema_version": 1,
+      "scientific_backend": "cpu_reference",
+      "scientific_execution_authorized": false,
+      "workload": "compute_requal_preflight"
+    }
+  ],
+  "matrix_id": "QTR-COMPUTE-REQUAL-001",
+  "schema_version": 1,
+  "status": "PREQUALIFICATION_ONLY__NO_MATERIALIZATION"
+}

--- a/reference/qtr_colab_runtime_probe.py
+++ b/reference/qtr_colab_runtime_probe.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+ALLOWED_GPU = {"T4", "L4", "A100", "H100", "G4"}
+ALLOWED_TPU = {"v5e1", "v6e1", "V5E1", "V6E1"}
+
+
+def optional_import(name: str):
+    try:
+        return __import__(name)
+    except Exception:
+        return None
+
+
+def proc_meminfo() -> dict[str, int]:
+    path = Path("/proc/meminfo")
+    out: dict[str, int] = {}
+    if not path.exists():
+        return out
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        fields = value.strip().split()
+        if fields and fields[0].isdigit():
+            amount = int(fields[0])
+            if len(fields) > 1 and fields[1].lower() == "kb":
+                amount *= 1024
+            out[key] = amount
+    return out
+
+
+def nvidia_info() -> list[dict[str, str]]:
+    if shutil.which("nvidia-smi") is None:
+        return []
+    proc = subprocess.run(
+        [
+            "nvidia-smi",
+            "--query-gpu=name,memory.total,driver_version",
+            "--format=csv,noheader,nounits",
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    if proc.returncode:
+        return []
+    rows = []
+    for line in proc.stdout.splitlines():
+        parts = [part.strip() for part in line.split(",")]
+        if len(parts) >= 3:
+            rows.append({"name": parts[0], "memory_total_mib": parts[1], "driver": parts[2]})
+    return rows
+
+
+def jax_info() -> tuple[str | None, list[dict[str, str]]]:
+    jax = optional_import("jax")
+    if jax is None:
+        return None, []
+    rows = []
+    try:
+        for device in jax.devices():
+            rows.append({
+                "platform": str(getattr(device, "platform", "")),
+                "device_kind": str(getattr(device, "device_kind", "")),
+                "id": str(getattr(device, "id", "")),
+            })
+    except Exception as exc:
+        rows.append({"platform": "ERROR", "device_kind": type(exc).__name__, "id": ""})
+    return str(getattr(jax, "__version__", "unknown")), rows
+
+
+def torch_info() -> dict[str, Any]:
+    torch = optional_import("torch")
+    if torch is None:
+        return {"available": False}
+    out: dict[str, Any] = {
+        "available": True,
+        "version": str(getattr(torch, "__version__", "unknown")),
+        "cuda_available": bool(torch.cuda.is_available()),
+        "cuda_version": str(getattr(torch.version, "cuda", None)),
+    }
+    if torch.cuda.is_available():
+        out["device_count"] = torch.cuda.device_count()
+        out["device_names"] = [torch.cuda.get_device_name(i) for i in range(torch.cuda.device_count())]
+    return out
+
+
+def detect_runtime() -> dict[str, Any]:
+    mem = proc_meminfo()
+    disk = shutil.disk_usage("/content" if Path("/content").exists() else "/")
+    gpu = nvidia_info()
+    torch = torch_info()
+    jax_version, jax_devices = jax_info()
+    tpu_devices = [row for row in jax_devices if row.get("platform") == "tpu"]
+    if tpu_devices:
+        variant = "TPU"
+        accelerator = "; ".join(row.get("device_kind", "") for row in tpu_devices)
+    elif gpu or torch.get("cuda_available"):
+        variant = "GPU"
+        names = [row["name"] for row in gpu] or list(torch.get("device_names", []))
+        accelerator = "; ".join(names)
+    else:
+        variant = "CPU"
+        accelerator = None
+    return {
+        "observed_variant": variant,
+        "observed_accelerator": accelerator,
+        "python": sys.version,
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "cpu_count": os.cpu_count(),
+        "memory_total_bytes": mem.get("MemTotal"),
+        "memory_available_bytes": mem.get("MemAvailable"),
+        "disk_total_bytes": disk.total,
+        "disk_free_bytes": disk.free,
+        "nvidia": gpu,
+        "torch": torch,
+        "jax_version": jax_version,
+        "jax_devices": jax_devices,
+    }
+
+
+def normalize(text: str | None) -> str:
+    return "".join(ch for ch in (text or "").lower() if ch.isalnum())
+
+
+def validate_requested_runtime(job: dict[str, Any], runtime: dict[str, Any]) -> None:
+    requested = job["resource"]
+    variant = str(requested["variant"]).upper()
+    observed = runtime["observed_variant"]
+    accelerator = requested.get("accelerator")
+    if variant == "DEFAULT":
+        variant = "CPU"
+    if observed != variant:
+        raise RuntimeError(f"requested {variant}, observed {observed}")
+    if variant == "GPU":
+        if accelerator not in ALLOWED_GPU:
+            raise RuntimeError(f"unsupported requested GPU {accelerator}")
+        if normalize(str(accelerator)) not in normalize(runtime.get("observed_accelerator")):
+            raise RuntimeError(
+                f"requested GPU {accelerator}, observed {runtime.get('observed_accelerator')}"
+            )
+    if variant == "TPU":
+        if accelerator not in ALLOWED_TPU:
+            raise RuntimeError(f"unsupported requested TPU {accelerator}")
+        observed_text = normalize(runtime.get("observed_accelerator"))
+        required_family = "v5" if "5" in str(accelerator) else "v6"
+        if required_family not in observed_text:
+            raise RuntimeError(
+                f"requested TPU {accelerator}, observed {runtime.get('observed_accelerator')}"
+            )
+
+
+def validate_job(job: dict[str, Any]) -> None:
+    required = {
+        "schema_version",
+        "experiment_id",
+        "workload",
+        "resource",
+        "remote_timeout_seconds",
+        "scientific_backend",
+        "scientific_execution_authorized",
+        "claim_boundary",
+        "enabled",
+    }
+    allowed = required | {"nominal_envelope_multiplier", "required_authorization"}
+    missing = required - set(job)
+    unknown = set(job) - allowed
+    if missing or unknown:
+        raise ValueError(f"job keys invalid missing={sorted(missing)} unknown={sorted(unknown)}")
+    if job["schema_version"] != 1:
+        raise ValueError("schema_version must be 1")
+    if job["scientific_execution_authorized"] is not False:
+        raise ValueError("preparation jobs may not authorize scientific execution")
+
+
+def cpu_probe() -> dict[str, Any]:
+    n = 1 << 20
+    mask = (1 << 63) - 1
+    start = time.perf_counter()
+    checksum = 0
+    value = 0x123456789ABCDEF
+    for i in range(n):
+        value = ((value * 6364136223846793005 + 1442695040888963407) & mask)
+        checksum ^= value ^ i
+    elapsed = time.perf_counter() - start
+    return {"elements": n, "checksum": checksum, "elapsed_seconds_diagnostic": elapsed}
+
+
+def gpu_probe() -> dict[str, Any] | None:
+    torch = optional_import("torch")
+    if torch is None or not torch.cuda.is_available():
+        return None
+    n = 1 << 20
+    start = time.perf_counter()
+    x = torch.arange(n, dtype=torch.int64, device="cuda")
+    y = torch.bitwise_xor(x, 0x55AA55AA)
+    checksum = int(y.sum().item())
+    torch.cuda.synchronize()
+    elapsed = time.perf_counter() - start
+    return {"elements": n, "checksum": checksum, "elapsed_seconds_diagnostic": elapsed}
+
+
+def tpu_probe() -> dict[str, Any] | None:
+    jax = optional_import("jax")
+    if jax is None:
+        return None
+    devices = [d for d in jax.devices() if getattr(d, "platform", None) == "tpu"]
+    if not devices:
+        return None
+    import jax.numpy as jnp
+    n = 1 << 20
+    start = time.perf_counter()
+    x = jnp.arange(n, dtype=jnp.int32)
+    y = jnp.bitwise_xor(x, jnp.int32(0x55AA55AA))
+    checksum_arr = jnp.sum(y, dtype=jnp.int64)
+    checksum = int(checksum_arr.block_until_ready())
+    elapsed = time.perf_counter() - start
+    return {"elements": n, "checksum": checksum, "elapsed_seconds_diagnostic": elapsed}
+
+
+def run_probe(job: dict[str, Any]) -> dict[str, Any]:
+    validate_job(job)
+    runtime = detect_runtime()
+    validate_requested_runtime(job, runtime)
+    probes = {"cpu": cpu_probe(), "gpu": None, "tpu": None}
+    if runtime["observed_variant"] == "GPU":
+        probes["gpu"] = gpu_probe()
+        if probes["gpu"] is None:
+            raise RuntimeError("GPU requested/observed but GPU functional probe unavailable")
+    elif runtime["observed_variant"] == "TPU":
+        probes["tpu"] = tpu_probe()
+        if probes["tpu"] is None:
+            raise RuntimeError("TPU requested/observed but TPU functional probe unavailable")
+    return {
+        "schema_version": 1,
+        "experiment_id": job["experiment_id"],
+        "status": "GREEN_ENGINEERING",
+        "runtime": runtime,
+        "functional_probes": probes,
+        "scientific_backend": job["scientific_backend"],
+        "accelerator_scientifically_used": False,
+        "timings_are_engineering_diagnostics_only": True,
+        "claim_boundary": job["claim_boundary"],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--job", type=Path, required=True)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--validate-job", action="store_true")
+    args = parser.parse_args()
+    job = json.loads(args.job.read_text(encoding="utf-8"))
+    validate_job(job)
+    if args.validate_job:
+        print("[QTR] job validation: PASS")
+        return 0
+    if args.output is None:
+        parser.error("--output is required unless --validate-job is used")
+    result = run_probe(job)
+    args.output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"status": result["status"], "runtime": result["runtime"]}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reference/qtr_compute_requal_001.py
+++ b/reference/qtr_compute_requal_001.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+HERE = Path(__file__).resolve().parent
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
+
+import qldpc_scale_001b as scale001b
+import qec_circuit_002 as circuit002
+
+ORIGINAL_PEAK_CAP = 1 << 20
+EXPECTED = {
+    "C72": 18,
+    "C90": 25,
+    "R0_BASELINE_107_FACTOR": 34,
+    "R1_TERMINAL_DIRECT_AUX": 36,
+    "R2_TERMINAL_CHAIN_AUX": 36,
+    "R3_CAUSAL_STATE_CHAIN": 36,
+}
+
+
+def peak_entries(width: int) -> int:
+    return 1 << (width + 1)
+
+
+def multiplier_needed(width: int) -> float:
+    return peak_entries(width) / ORIGINAL_PEAK_CAP
+
+
+def load_job(path: Path) -> dict[str, Any]:
+    job = json.loads(path.read_text(encoding="utf-8"))
+    if job.get("workload") != "compute_requal_preflight":
+        raise ValueError("wrong workload")
+    if job.get("scientific_execution_authorized") is not False:
+        raise ValueError("preflight may not authorize scientific execution")
+    multiplier = job.get("nominal_envelope_multiplier")
+    if not isinstance(multiplier, int) or multiplier <= 0:
+        raise ValueError("nominal_envelope_multiplier must be a positive integer")
+    return job
+
+
+def scale_widths() -> dict[str, int]:
+    manifest = scale001b.load_manifest(ROOT / scale001b.MANIFEST_PATH)
+    rungs = {int(row["n"]): row for row in manifest["ladder"]}
+    out = {}
+    for n in (72, 90):
+        code = scale001b.construct_rung(rungs[n])
+        audit = scale001b.order_audit(code["scopes"])
+        out[f"C{n}"] = int(audit["widths"]["min_fill"])
+    return out
+
+
+def temporal_widths() -> dict[str, int]:
+    circuit002.load_manifest()
+    out = {}
+    for rep in (
+        "R0_BASELINE_107_FACTOR",
+        "R1_TERMINAL_DIRECT_AUX",
+        "R2_TERMINAL_CHAIN_AUX",
+        "R3_CAUSAL_STATE_CHAIN",
+    ):
+        variable_count, scopes = circuit002.representation_scopes(rep)
+        result = circuit002.elimination_order(
+            circuit002.primal_graph(scopes, variable_count),
+            "deterministic_min_fill",
+        )
+        out[rep] = int(result["induced_width"])
+    return out
+
+
+def evaluate(job: dict[str, Any]) -> dict[str, Any]:
+    widths = {**scale_widths(), **temporal_widths()}
+    if widths != EXPECTED:
+        raise ValueError(f"protected structural identity drift: {widths}")
+    multiplier = int(job["nominal_envelope_multiplier"])
+    nominal_cap = ORIGINAL_PEAK_CAP * multiplier
+    rows = []
+    for name, width in widths.items():
+        peak = peak_entries(width)
+        rows.append({
+            "target": name,
+            "protected_min_fill_width": width,
+            "predicted_peak_joint_table_entries": peak,
+            "multiplier_needed_vs_original_peak_cap": multiplier_needed(width),
+            "inside_nominal_entry_cap": peak <= nominal_cap,
+            "physical_materialization_authorized": False,
+        })
+    return {
+        "schema_version": 1,
+        "experiment_id": job["experiment_id"],
+        "status": "GREEN_ENGINEERING_PREQUALIFICATION",
+        "original_peak_entry_cap": ORIGINAL_PEAK_CAP,
+        "nominal_envelope_multiplier": multiplier,
+        "nominal_peak_entry_cap": nominal_cap,
+        "rows": rows,
+        "c90_crosses_nominal_entry_cap": next(
+            row["inside_nominal_entry_cap"] for row in rows if row["target"] == "C90"
+        ),
+        "temporal_r0_crosses_nominal_entry_cap": next(
+            row["inside_nominal_entry_cap"]
+            for row in rows
+            if row["target"] == "R0_BASELINE_107_FACTOR"
+        ),
+        "physical_memory_eligibility_decided": False,
+        "physical_memory_note": (
+            "Entry-count requalification is not permission to materialize. "
+            "Observed Colab RAM and representation-specific storage must be checked "
+            "under a separately authorized exact-execution contract."
+        ),
+        "scientific_execution_performed": False,
+        "scientific_disposition_authorized": False,
+        "claim_boundary": job["claim_boundary"],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--job", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    result = evaluate(load_job(args.job))
+    args.output.write_text(
+        json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(json.dumps({
+        "status": result["status"],
+        "c90_crosses_nominal_entry_cap": result["c90_crosses_nominal_entry_cap"],
+        "temporal_r0_crosses_nominal_entry_cap": result["temporal_r0_crosses_nominal_entry_cap"],
+    }, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bootstrap_colab_runner_env.sh
+++ b/scripts/bootstrap_colab_runner_env.sh
@@ -28,7 +28,13 @@ while [[ $# -gt 0 ]]; do
 done
 
 command -v uv >/dev/null 2>&1 || die "uv is required"
+UV_BIN="$(command -v uv)"
 mkdir -p "$ARTIFACT_DIR"
+
+if [[ "$VERIFY_ONLY" -eq 0 ]]; then
+  say "ensuring Python $PYTHON_SERIES is available under uv"
+  "$UV_BIN" python install "$PYTHON_SERIES"
+fi
 
 if [[ "$REBUILD" -eq 1 && "$VERIFY_ONLY" -eq 0 ]]; then
   rm -rf "$VENV_DIR"
@@ -37,26 +43,35 @@ fi
 if [[ ! -x "$VENV_DIR/bin/python" ]]; then
   [[ "$VERIFY_ONLY" -eq 0 ]] || die ".venv missing in --verify-only mode"
   say "creating Python $PYTHON_SERIES runner environment"
-  uv venv --python "$PYTHON_SERIES" "$VENV_DIR"
+  "$UV_BIN" venv --python "$PYTHON_SERIES" --seed "$VENV_DIR"
 fi
 
 VENV_PY="$VENV_DIR/bin/python"
+ACTUAL_SERIES="$($VENV_PY -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+[[ "$ACTUAL_SERIES" == "$PYTHON_SERIES" ]] || die "expected Python $PYTHON_SERIES, found $ACTUAL_SERIES"
 
 if [[ "$VERIFY_ONLY" -eq 0 ]]; then
   say "installing local runner test dependencies"
-  uv pip install --python "$VENV_PY" "pytest>=8,<9"
+  "$UV_BIN" pip install --python "$VENV_PY" "pytest>=8,<9"
   say "installing isolated Colab CLI toolchain"
-  uv tool install --force "google-colab-cli==$COLAB_CLI_VERSION" \
-    --with "jupyter-kernel-client==$JUPYTER_KERNEL_CLIENT_VERSION"
+  "$UV_BIN" tool install --force --python "$PYTHON_SERIES" \
+    --with "jupyter-kernel-client==$JUPYTER_KERNEL_CLIENT_VERSION" \
+    "google-colab-cli==$COLAB_CLI_VERSION"
 fi
 
-COLAB_BIN="$(command -v colab || true)"
-[[ -n "$COLAB_BIN" ]] || die "colab CLI not found on PATH"
+TOOL_BIN_DIR="$($UV_BIN tool dir --bin)"
+COLAB_BIN="$TOOL_BIN_DIR/colab"
+[[ -x "$COLAB_BIN" ]] || die "Colab CLI executable not found at $COLAB_BIN"
+ln -sfn "$COLAB_BIN" "$VENV_DIR/bin/colab"
+export PATH="$VENV_DIR/bin:$TOOL_BIN_DIR:$PATH"
+command -v colab >/dev/null 2>&1 || die "colab CLI is not visible on PATH"
+colab --help >/dev/null 2>&1 || die "colab CLI exists but cannot start"
 
-say "checking Colab CLI version"
+say "checking Colab CLI provenance"
+"$UV_BIN" tool list > "$ARTIFACT_DIR/uv-tool-list.txt"
+grep -q "google-colab-cli v$COLAB_CLI_VERSION" "$ARTIFACT_DIR/uv-tool-list.txt" \
+  || die "uv tool list does not report google-colab-cli v$COLAB_CLI_VERSION"
 colab version > "$ARTIFACT_DIR/colab-version.txt" 2>&1
-grep -q "$COLAB_CLI_VERSION" "$ARTIFACT_DIR/colab-version.txt" \
-  || die "expected google-colab-cli $COLAB_CLI_VERSION"
 
 if [[ "$CHECK_AUTH" -eq 1 ]]; then
   say "checking Colab access (auth=$COLAB_AUTH)"

--- a/scripts/bootstrap_colab_runner_env.sh
+++ b/scripts/bootstrap_colab_runner_env.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+REBUILD=0
+VERIFY_ONLY=0
+CHECK_AUTH=1
+COLAB_AUTH="${COLAB_AUTH:-oauth2}"
+PYTHON_SERIES="3.12"
+COLAB_CLI_VERSION="0.6.0"
+JUPYTER_KERNEL_CLIENT_VERSION="0.9.0"
+VENV_DIR="$ROOT/.venv"
+ARTIFACT_DIR="$ROOT/.artifacts/bootstrap"
+
+say() { printf '[QTR] %s\n' "$*"; }
+die() { printf '[QTR] ERROR: %s\n' "$*" >&2; exit 1; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --rebuild) REBUILD=1 ;;
+    --verify-only) VERIFY_ONLY=1 ;;
+    --skip-auth-check) CHECK_AUTH=0 ;;
+    *) die "unknown option: $1" ;;
+  esac
+  shift
+done
+
+command -v uv >/dev/null 2>&1 || die "uv is required"
+mkdir -p "$ARTIFACT_DIR"
+
+if [[ "$REBUILD" -eq 1 && "$VERIFY_ONLY" -eq 0 ]]; then
+  rm -rf "$VENV_DIR"
+fi
+
+if [[ ! -x "$VENV_DIR/bin/python" ]]; then
+  [[ "$VERIFY_ONLY" -eq 0 ]] || die ".venv missing in --verify-only mode"
+  say "creating Python $PYTHON_SERIES runner environment"
+  uv venv --python "$PYTHON_SERIES" "$VENV_DIR"
+fi
+
+VENV_PY="$VENV_DIR/bin/python"
+
+if [[ "$VERIFY_ONLY" -eq 0 ]]; then
+  say "installing local runner test dependencies"
+  uv pip install --python "$VENV_PY" "pytest>=8,<9"
+  say "installing isolated Colab CLI toolchain"
+  uv tool install --force "google-colab-cli==$COLAB_CLI_VERSION" \
+    --with "jupyter-kernel-client==$JUPYTER_KERNEL_CLIENT_VERSION"
+fi
+
+COLAB_BIN="$(command -v colab || true)"
+[[ -n "$COLAB_BIN" ]] || die "colab CLI not found on PATH"
+
+say "checking Colab CLI version"
+colab version > "$ARTIFACT_DIR/colab-version.txt" 2>&1
+grep -q "$COLAB_CLI_VERSION" "$ARTIFACT_DIR/colab-version.txt" \
+  || die "expected google-colab-cli $COLAB_CLI_VERSION"
+
+if [[ "$CHECK_AUTH" -eq 1 ]]; then
+  say "checking Colab access (auth=$COLAB_AUTH)"
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 45 colab --auth="$COLAB_AUTH" sessions \
+      > "$ARTIFACT_DIR/colab-sessions.txt" 2>&1 \
+      || die "Colab auth/session check failed"
+  else
+    colab --auth="$COLAB_AUTH" sessions \
+      > "$ARTIFACT_DIR/colab-sessions.txt" 2>&1 \
+      || die "Colab auth/session check failed"
+  fi
+else
+  printf 'SKIPPED\n' > "$ARTIFACT_DIR/colab-sessions.txt"
+fi
+
+say "compiling runner entrypoints"
+"$VENV_PY" -m py_compile \
+  scripts/build_colab_payload.py \
+  scripts/colab_run_matrix.py \
+  colab/qtr_remote_job.py \
+  reference/qtr_colab_runtime_probe.py \
+  reference/qtr_compute_requal_001.py
+
+bash -n scripts/colab_run_job.sh
+bash -n scripts/bootstrap_colab_runner_env.sh
+
+say "running bounded runner tests"
+"$VENV_PY" -m pytest -q tests/test_qtr_colab_compute_001.py --import-mode=importlib
+
+say "checking deterministic source payload"
+"$VENV_PY" scripts/build_colab_payload.py --check
+
+say "writing environment receipt"
+"$VENV_PY" - "$ARTIFACT_DIR" "$COLAB_BIN" "$COLAB_AUTH" "$CHECK_AUTH" <<'PY'
+from __future__ import annotations
+import hashlib, json, platform, subprocess, sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+artifact = Path(sys.argv[1])
+colab_bin = sys.argv[2]
+auth = sys.argv[3]
+auth_checked = bool(int(sys.argv[4]))
+root = Path.cwd()
+
+def sha(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for block in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(block)
+    return h.hexdigest()
+
+receipt = {
+    "schema_version": 1,
+    "audit_id": "QTR-COLAB-RUNNER-ENVIRONMENT-001",
+    "created_at": datetime.now(timezone.utc).isoformat(),
+    "python": sys.version,
+    "platform": platform.platform(),
+    "colab_cli": subprocess.check_output([colab_bin, "version"], text=True).strip(),
+    "colab_auth_provider": auth,
+    "colab_auth_checked": auth_checked,
+    "source_commit": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+    "entrypoint_sha256": {
+        "scripts/build_colab_payload.py": sha(root / "scripts/build_colab_payload.py"),
+        "scripts/colab_run_job.sh": sha(root / "scripts/colab_run_job.sh"),
+        "scripts/colab_run_matrix.py": sha(root / "scripts/colab_run_matrix.py"),
+        "colab/qtr_remote_job.py": sha(root / "colab/qtr_remote_job.py"),
+    },
+    "claim_boundary": {
+        "engineering_environment_only": True,
+        "scientific_execution_authorized": False,
+        "promotion_authorized": False,
+    },
+}
+(artifact / "QTR_COLAB_RUNNER_ENVIRONMENT_RECEIPT.json").write_text(
+    json.dumps(receipt, indent=2, sort_keys=True) + "\n"
+)
+PY
+
+say "runner environment GREEN"

--- a/scripts/build_colab_payload.py
+++ b/scripts/build_colab_payload.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import io
+import json
+import os
+import subprocess
+import tarfile
+import tempfile
+from pathlib import Path
+from typing import Iterable
+
+ROOT = Path(__file__).resolve().parents[1]
+
+EXCLUDED_PARTS = {
+    ".git",
+    ".venv",
+    ".pytest_cache",
+    "__pycache__",
+    ".artifacts",
+    "runs",
+    "receipts",
+    "analysis",
+    "dist",
+    "build",
+}
+EXCLUDED_SUFFIXES = {".pyc", ".pyo", ".zip"}
+EXCLUDED_NAMES = {"gcl_source.tar.gz", "gcl_manifest.json", "gcl_job.json"}
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def git_head() -> str:
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=ROOT, text=True
+    ).strip()
+
+
+def include_path(path: Path) -> bool:
+    rel = path.relative_to(ROOT)
+    if any(part in EXCLUDED_PARTS for part in rel.parts):
+        return False
+    if path.suffix in EXCLUDED_SUFFIXES:
+        return False
+    if path.name in EXCLUDED_NAMES or path.name.endswith(".tar.gz"):
+        return False
+    return path.is_file()
+
+
+def governed_files() -> list[Path]:
+    return sorted(
+        (path for path in ROOT.rglob("*") if include_path(path)),
+        key=lambda path: path.relative_to(ROOT).as_posix(),
+    )
+
+
+def tar_bytes(paths: Iterable[Path]) -> bytes:
+    raw = io.BytesIO()
+    with tarfile.open(fileobj=raw, mode="w") as archive:
+        for path in paths:
+            rel = path.relative_to(ROOT).as_posix()
+            data = path.read_bytes()
+            info = tarfile.TarInfo(name=rel)
+            info.size = len(data)
+            info.mode = 0o755 if os.access(path, os.X_OK) else 0o644
+            info.uid = 0
+            info.gid = 0
+            info.uname = ""
+            info.gname = ""
+            info.mtime = 0
+            archive.addfile(info, io.BytesIO(data))
+    compressed = io.BytesIO()
+    with gzip.GzipFile(fileobj=compressed, mode="wb", mtime=0, filename="") as gz:
+        gz.write(raw.getvalue())
+    return compressed.getvalue()
+
+
+def build(output: Path, manifest_path: Path) -> dict[str, object]:
+    paths = governed_files()
+    payload = tar_bytes(paths)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_bytes(payload)
+    manifest = {
+        "schema_version": 1,
+        "kind": "QTR_COLAB_SOURCE_PAYLOAD",
+        "source_commit": git_head(),
+        "payload_sha256": sha256_bytes(payload),
+        "file_count": len(paths),
+        "files": [
+            {
+                "path": path.relative_to(ROOT).as_posix(),
+                "bytes": path.stat().st_size,
+                "sha256": sha256_file(path),
+            }
+            for path in paths
+        ],
+        "excluded_top_level_runtime_outputs": sorted(EXCLUDED_PARTS),
+    }
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return manifest
+
+
+def check_deterministic() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        a, ma = tmp / "a.tar.gz", tmp / "a.json"
+        b, mb = tmp / "b.tar.gz", tmp / "b.json"
+        first = build(a, ma)
+        second = build(b, mb)
+        if a.read_bytes() != b.read_bytes():
+            raise SystemExit("deterministic payload check failed: archive bytes differ")
+        if first != second:
+            raise SystemExit("deterministic payload check failed: manifests differ")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--manifest", type=Path)
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    if args.check:
+        check_deterministic()
+        print("[QTR] deterministic Colab payload: PASS")
+        return 0
+    if not args.output or not args.manifest:
+        parser.error("--output and --manifest are required unless --check is used")
+    manifest = build(args.output, args.manifest)
+    print(
+        f"[QTR] payload={args.output} sha256={manifest['payload_sha256']} "
+        f"files={manifest['file_count']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/colab_run_job.sh
+++ b/scripts/colab_run_job.sh
@@ -101,17 +101,35 @@ colab --auth="$COLAB_AUTH" download -s "$SESSION" \
   /content/gcl_output_bundle.tar.gz "$LOCAL_RUN/gcl_output_bundle.tar.gz" \
   > "$LOCAL_RUN/download-bundle.txt" 2>&1 || true
 
-if [[ -f "$LOCAL_RUN/experiment_receipt.json" ]]; then
-  python - "$LOCAL_RUN/experiment_receipt.json" <<'PY'
-import json, sys
-r=json.load(open(sys.argv[1], encoding="utf-8"))
-print("[QTR] remote receipt status:", r.get("status"))
-print("[QTR] observed runtime:", r.get("runtime",{}).get("observed_variant"),
-      r.get("runtime",{}).get("observed_accelerator"))
-if r.get("status") != "GREEN_ENGINEERING":
+[[ -f "$LOCAL_RUN/experiment_receipt.json" ]] || {
+  echo "[QTR] missing experiment receipt; evidence retained at $LOCAL_RUN" >&2
+  exit 11
+}
+[[ -f "$LOCAL_RUN/gcl_output_bundle.tar.gz" ]] || {
+  echo "[QTR] missing output bundle; evidence retained at $LOCAL_RUN" >&2
+  exit 12
+}
+
+python - "$LOCAL_RUN/experiment_receipt.json" "$MANIFEST" "$LOCAL_RUN/gcl_job.json" <<'PY'
+import hashlib, json, sys
+from pathlib import Path
+receipt=json.load(open(sys.argv[1], encoding="utf-8"))
+manifest=json.load(open(sys.argv[2], encoding="utf-8"))
+job_path=Path(sys.argv[3])
+def sha(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+print("[QTR] remote receipt status:", receipt.get("status"))
+print("[QTR] observed runtime:", receipt.get("runtime",{}).get("observed_variant"),
+      receipt.get("runtime",{}).get("observed_accelerator"))
+if receipt.get("status") != "GREEN_ENGINEERING":
     raise SystemExit(10)
+if receipt.get("source_commit") != manifest.get("source_commit"):
+    raise SystemExit("receipt source commit mismatch")
+if receipt.get("source_payload_sha256") != manifest.get("payload_sha256"):
+    raise SystemExit("receipt source payload mismatch")
+if receipt.get("job_sha256") != sha(job_path):
+    raise SystemExit("receipt job digest mismatch")
 PY
-fi
 
 if [[ "$REMOTE_RC" -ne 0 ]]; then
   echo "[QTR] remote execution failed rc=$REMOTE_RC; evidence retained at $LOCAL_RUN" >&2

--- a/scripts/colab_run_job.sh
+++ b/scripts/colab_run_job.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+JOB="${1:-}"
+[[ -n "$JOB" && -f "$JOB" ]] || {
+  echo "usage: $0 <job.json>" >&2
+  exit 2
+}
+
+COLAB_AUTH="${COLAB_AUTH:-oauth2}"
+
+readarray -t META < <(python - "$JOB" <<'PY'
+import json, sys
+job=json.load(open(sys.argv[1], encoding="utf-8"))
+required={"schema_version","experiment_id","workload","resource","remote_timeout_seconds",
+          "scientific_backend","scientific_execution_authorized","claim_boundary"}
+missing=required-set(job)
+if missing:
+    raise SystemExit(f"missing job keys: {sorted(missing)}")
+r=job["resource"]
+variant=str(r["variant"]).upper()
+accelerator=r.get("accelerator") or ""
+print(job["experiment_id"])
+print(variant)
+print(accelerator)
+print(int(job["remote_timeout_seconds"]))
+PY
+)
+
+EXPERIMENT_ID="${META[0]}"
+VARIANT="${META[1]}"
+ACCELERATOR="${META[2]}"
+REMOTE_TIMEOUT="${META[3]}"
+RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+SESSION="gcl-qtr-$(printf '%s' "$EXPERIMENT_ID" | tr '[:upper:]_' '[:lower:]-' | tr -cd 'a-z0-9.-' | cut -c1-42)-$$"
+LOCAL_RUN="$ROOT/runs/hosted/$EXPERIMENT_ID/$RUN_ID"
+mkdir -p "$LOCAL_RUN"
+
+PAYLOAD="$LOCAL_RUN/gcl_source.tar.gz"
+MANIFEST="$LOCAL_RUN/gcl_manifest.json"
+cp "$JOB" "$LOCAL_RUN/gcl_job.json"
+
+python scripts/build_colab_payload.py --output "$PAYLOAD" --manifest "$MANIFEST"
+
+ALLOCATED=0
+cleanup() {
+  rc=$?
+  set +e
+  if [[ "$ALLOCATED" -eq 1 ]]; then
+    colab --auth="$COLAB_AUTH" log -s "$SESSION" -o "$LOCAL_RUN/colab-execution.md" \
+      > "$LOCAL_RUN/colab-log-command.txt" 2>&1 || true
+    colab --auth="$COLAB_AUTH" stop -s "$SESSION" \
+      > "$LOCAL_RUN/colab-stop.txt" 2>&1 || true
+  fi
+  colab --auth="$COLAB_AUTH" sessions > "$LOCAL_RUN/colab-sessions-after.txt" 2>&1 || true
+  exit "$rc"
+}
+trap cleanup EXIT INT TERM
+
+echo "[QTR] allocating session=$SESSION variant=$VARIANT accelerator=${ACCELERATOR:-none}"
+case "$VARIANT" in
+  CPU|DEFAULT)
+    colab --auth="$COLAB_AUTH" new -s "$SESSION"
+    ;;
+  GPU)
+    [[ -n "$ACCELERATOR" ]] || { echo "GPU accelerator missing" >&2; exit 3; }
+    colab --auth="$COLAB_AUTH" new -s "$SESSION" --gpu "$ACCELERATOR"
+    ;;
+  TPU)
+    [[ -n "$ACCELERATOR" ]] || { echo "TPU accelerator missing" >&2; exit 3; }
+    colab --auth="$COLAB_AUTH" new -s "$SESSION" --tpu "$ACCELERATOR"
+    ;;
+  *)
+    echo "unsupported resource variant: $VARIANT" >&2
+    exit 3
+    ;;
+esac
+ALLOCATED=1
+
+colab --auth="$COLAB_AUTH" status -s "$SESSION" > "$LOCAL_RUN/colab-status.txt"
+
+colab --auth="$COLAB_AUTH" upload -s "$SESSION" "$PAYLOAD" /content/gcl_source.tar.gz
+colab --auth="$COLAB_AUTH" upload -s "$SESSION" "$LOCAL_RUN/gcl_job.json" /content/gcl_job.json
+colab --auth="$COLAB_AUTH" upload -s "$SESSION" "$MANIFEST" /content/gcl_manifest.json
+
+set +e
+colab --auth="$COLAB_AUTH" exec -s "$SESSION" -f "$ROOT/colab/qtr_remote_job.py" \
+  --timeout "$REMOTE_TIMEOUT" \
+  > >(tee "$LOCAL_RUN/remote-stdout.txt") \
+  2> >(tee "$LOCAL_RUN/remote-stderr.txt" >&2)
+REMOTE_RC=$?
+set -e
+
+colab --auth="$COLAB_AUTH" download -s "$SESSION" \
+  /content/experiment_receipt.json "$LOCAL_RUN/experiment_receipt.json" \
+  > "$LOCAL_RUN/download-receipt.txt" 2>&1 || true
+colab --auth="$COLAB_AUTH" download -s "$SESSION" \
+  /content/gcl_output_bundle.tar.gz "$LOCAL_RUN/gcl_output_bundle.tar.gz" \
+  > "$LOCAL_RUN/download-bundle.txt" 2>&1 || true
+
+if [[ -f "$LOCAL_RUN/experiment_receipt.json" ]]; then
+  python - "$LOCAL_RUN/experiment_receipt.json" <<'PY'
+import json, sys
+r=json.load(open(sys.argv[1], encoding="utf-8"))
+print("[QTR] remote receipt status:", r.get("status"))
+print("[QTR] observed runtime:", r.get("runtime",{}).get("observed_variant"),
+      r.get("runtime",{}).get("observed_accelerator"))
+if r.get("status") != "GREEN_ENGINEERING":
+    raise SystemExit(10)
+PY
+fi
+
+if [[ "$REMOTE_RC" -ne 0 ]]; then
+  echo "[QTR] remote execution failed rc=$REMOTE_RC; evidence retained at $LOCAL_RUN" >&2
+  exit "$REMOTE_RC"
+fi
+
+echo "[QTR] hosted engineering job GREEN: $LOCAL_RUN"

--- a/scripts/colab_run_job.sh
+++ b/scripts/colab_run_job.sh
@@ -10,9 +10,13 @@ JOB="${1:-}"
   exit 2
 }
 
+VENV_PY="$ROOT/.venv/bin/python"
+COLAB_BIN="$ROOT/.venv/bin/colab"
+[[ -x "$VENV_PY" ]] || { echo "missing $VENV_PY; run scripts/bootstrap_colab_runner_env.sh" >&2; exit 2; }
+[[ -x "$COLAB_BIN" ]] || { echo "missing $COLAB_BIN; run scripts/bootstrap_colab_runner_env.sh" >&2; exit 2; }
 COLAB_AUTH="${COLAB_AUTH:-oauth2}"
 
-readarray -t META < <(python - "$JOB" <<'PY'
+readarray -t META < <("$VENV_PY" - "$JOB" <<'PY'
 import json, sys
 job=json.load(open(sys.argv[1], encoding="utf-8"))
 required={"schema_version","experiment_id","workload","resource","remote_timeout_seconds",
@@ -43,19 +47,19 @@ PAYLOAD="$LOCAL_RUN/gcl_source.tar.gz"
 MANIFEST="$LOCAL_RUN/gcl_manifest.json"
 cp "$JOB" "$LOCAL_RUN/gcl_job.json"
 
-python scripts/build_colab_payload.py --output "$PAYLOAD" --manifest "$MANIFEST"
+"$VENV_PY" scripts/build_colab_payload.py --output "$PAYLOAD" --manifest "$MANIFEST"
 
 ALLOCATED=0
 cleanup() {
   rc=$?
   set +e
   if [[ "$ALLOCATED" -eq 1 ]]; then
-    colab --auth="$COLAB_AUTH" log -s "$SESSION" -o "$LOCAL_RUN/colab-execution.md" \
+    "$COLAB_BIN" --auth="$COLAB_AUTH" log -s "$SESSION" -o "$LOCAL_RUN/colab-execution.md" \
       > "$LOCAL_RUN/colab-log-command.txt" 2>&1 || true
-    colab --auth="$COLAB_AUTH" stop -s "$SESSION" \
+    "$COLAB_BIN" --auth="$COLAB_AUTH" stop -s "$SESSION" \
       > "$LOCAL_RUN/colab-stop.txt" 2>&1 || true
   fi
-  colab --auth="$COLAB_AUTH" sessions > "$LOCAL_RUN/colab-sessions-after.txt" 2>&1 || true
+  "$COLAB_BIN" --auth="$COLAB_AUTH" sessions > "$LOCAL_RUN/colab-sessions-after.txt" 2>&1 || true
   exit "$rc"
 }
 trap cleanup EXIT INT TERM
@@ -63,15 +67,15 @@ trap cleanup EXIT INT TERM
 echo "[QTR] allocating session=$SESSION variant=$VARIANT accelerator=${ACCELERATOR:-none}"
 case "$VARIANT" in
   CPU|DEFAULT)
-    colab --auth="$COLAB_AUTH" new -s "$SESSION"
+    "$COLAB_BIN" --auth="$COLAB_AUTH" new -s "$SESSION"
     ;;
   GPU)
     [[ -n "$ACCELERATOR" ]] || { echo "GPU accelerator missing" >&2; exit 3; }
-    colab --auth="$COLAB_AUTH" new -s "$SESSION" --gpu "$ACCELERATOR"
+    "$COLAB_BIN" --auth="$COLAB_AUTH" new -s "$SESSION" --gpu "$ACCELERATOR"
     ;;
   TPU)
     [[ -n "$ACCELERATOR" ]] || { echo "TPU accelerator missing" >&2; exit 3; }
-    colab --auth="$COLAB_AUTH" new -s "$SESSION" --tpu "$ACCELERATOR"
+    "$COLAB_BIN" --auth="$COLAB_AUTH" new -s "$SESSION" --tpu "$ACCELERATOR"
     ;;
   *)
     echo "unsupported resource variant: $VARIANT" >&2
@@ -80,24 +84,24 @@ case "$VARIANT" in
 esac
 ALLOCATED=1
 
-colab --auth="$COLAB_AUTH" status -s "$SESSION" > "$LOCAL_RUN/colab-status.txt"
+"$COLAB_BIN" --auth="$COLAB_AUTH" status -s "$SESSION" > "$LOCAL_RUN/colab-status.txt"
 
-colab --auth="$COLAB_AUTH" upload -s "$SESSION" "$PAYLOAD" /content/gcl_source.tar.gz
-colab --auth="$COLAB_AUTH" upload -s "$SESSION" "$LOCAL_RUN/gcl_job.json" /content/gcl_job.json
-colab --auth="$COLAB_AUTH" upload -s "$SESSION" "$MANIFEST" /content/gcl_manifest.json
+"$COLAB_BIN" --auth="$COLAB_AUTH" upload -s "$SESSION" "$PAYLOAD" /content/gcl_source.tar.gz
+"$COLAB_BIN" --auth="$COLAB_AUTH" upload -s "$SESSION" "$LOCAL_RUN/gcl_job.json" /content/gcl_job.json
+"$COLAB_BIN" --auth="$COLAB_AUTH" upload -s "$SESSION" "$MANIFEST" /content/gcl_manifest.json
 
 set +e
-colab --auth="$COLAB_AUTH" exec -s "$SESSION" -f "$ROOT/colab/qtr_remote_job.py" \
+"$COLAB_BIN" --auth="$COLAB_AUTH" exec -s "$SESSION" -f "$ROOT/colab/qtr_remote_job.py" \
   --timeout "$REMOTE_TIMEOUT" \
   > >(tee "$LOCAL_RUN/remote-stdout.txt") \
   2> >(tee "$LOCAL_RUN/remote-stderr.txt" >&2)
 REMOTE_RC=$?
 set -e
 
-colab --auth="$COLAB_AUTH" download -s "$SESSION" \
+"$COLAB_BIN" --auth="$COLAB_AUTH" download -s "$SESSION" \
   /content/experiment_receipt.json "$LOCAL_RUN/experiment_receipt.json" \
   > "$LOCAL_RUN/download-receipt.txt" 2>&1 || true
-colab --auth="$COLAB_AUTH" download -s "$SESSION" \
+"$COLAB_BIN" --auth="$COLAB_AUTH" download -s "$SESSION" \
   /content/gcl_output_bundle.tar.gz "$LOCAL_RUN/gcl_output_bundle.tar.gz" \
   > "$LOCAL_RUN/download-bundle.txt" 2>&1 || true
 
@@ -110,7 +114,7 @@ colab --auth="$COLAB_AUTH" download -s "$SESSION" \
   exit 12
 }
 
-python - "$LOCAL_RUN/experiment_receipt.json" "$MANIFEST" "$LOCAL_RUN/gcl_job.json" <<'PY'
+"$VENV_PY" - "$LOCAL_RUN/experiment_receipt.json" "$MANIFEST" "$LOCAL_RUN/gcl_job.json" <<'PY'
 import hashlib, json, sys
 from pathlib import Path
 receipt=json.load(open(sys.argv[1], encoding="utf-8"))

--- a/scripts/colab_run_matrix.py
+++ b/scripts/colab_run_matrix.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import re
+import subprocess
+
+ROOT = Path(__file__).resolve().parents[1]
+ALLOWED_GPU = {"T4", "L4", "A100", "H100", "G4"}
+ALLOWED_TPU = {"v5e1", "v6e1", "V5E1", "V6E1"}
+
+
+def safe_name(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip("-")
+
+
+def validate_job(job: dict) -> None:
+    required = {
+        "schema_version",
+        "experiment_id",
+        "workload",
+        "resource",
+        "remote_timeout_seconds",
+        "scientific_backend",
+        "scientific_execution_authorized",
+        "claim_boundary",
+        "enabled",
+    }
+    if set(job) - (required | {"nominal_envelope_multiplier", "required_authorization"}):
+        raise ValueError(f"unknown job keys: {sorted(set(job)-required-{'nominal_envelope_multiplier','required_authorization'})}")
+    missing = required - set(job)
+    if missing:
+        raise ValueError(f"missing job keys: {sorted(missing)}")
+    if job["schema_version"] != 1:
+        raise ValueError("job schema_version must be 1")
+    resource = job["resource"]
+    if set(resource) != {"variant", "accelerator"}:
+        raise ValueError("resource must contain exactly variant and accelerator")
+    variant = str(resource["variant"]).upper()
+    accelerator = resource["accelerator"]
+    if variant in {"CPU", "DEFAULT"}:
+        if accelerator not in {None, "", "NONE"}:
+            raise ValueError("CPU job may not request accelerator")
+    elif variant == "GPU":
+        if accelerator not in ALLOWED_GPU:
+            raise ValueError(f"unsupported GPU accelerator: {accelerator}")
+    elif variant == "TPU":
+        if accelerator not in ALLOWED_TPU:
+            raise ValueError(f"unsupported TPU accelerator: {accelerator}")
+    else:
+        raise ValueError(f"unsupported resource variant: {variant}")
+    if job["scientific_execution_authorized"] is not False:
+        raise ValueError(
+            "QTR-COLAB-COMPUTE-001 preparation matrix may not authorize scientific execution"
+        )
+    if job["workload"] not in {"runtime_probe", "compute_requal_preflight", "c90_exact_candidate"}:
+        raise ValueError(f"unsupported workload: {job['workload']}")
+    if job["workload"] == "c90_exact_candidate" and job["enabled"]:
+        raise ValueError("C90 exact candidate must remain disabled pending separate authority")
+
+
+def load_matrix(path: Path) -> dict:
+    matrix = json.loads(path.read_text(encoding="utf-8"))
+    required = {"schema_version", "matrix_id", "status", "jobs", "claim_boundary"}
+    if set(matrix) != required:
+        raise ValueError("matrix key mismatch")
+    if matrix["schema_version"] != 1:
+        raise ValueError("matrix schema_version must be 1")
+    seen = set()
+    for job in matrix["jobs"]:
+        validate_job(job)
+        if job["experiment_id"] in seen:
+            raise ValueError("duplicate experiment_id")
+        seen.add(job["experiment_id"])
+    return matrix
+
+
+def latest_green_receipt(experiment_id: str) -> Path | None:
+    base = ROOT / "runs" / "hosted" / experiment_id
+    for path in sorted(base.glob("*/experiment_receipt.json"), reverse=True):
+        try:
+            receipt = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if receipt.get("status") == "GREEN_ENGINEERING":
+            return path
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("matrix", type=Path)
+    parser.add_argument("--continue-on-error", action="store_true")
+    parser.add_argument("--resume", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    matrix = load_matrix(args.matrix)
+    matrix_id = matrix["matrix_id"]
+    work = ROOT / ".artifacts" / "colab-matrix" / safe_name(matrix_id)
+    jobs_dir = work / "jobs"
+    jobs_dir.mkdir(parents=True, exist_ok=True)
+
+    results = []
+    for idx, job in enumerate(matrix["jobs"], 1):
+        variant = job["resource"]["variant"]
+        accel = job["resource"]["accelerator"]
+        label = f"{variant}:{accel or 'default'}"
+        job_path = jobs_dir / f"{idx:03d}_{safe_name(job['experiment_id'])}.json"
+        job_path.write_text(json.dumps(job, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+        if not job["enabled"]:
+            print(f"[QTR] {matrix_id}: DISABLED {job['experiment_id']} ({label})")
+            results.append({"experiment_id": job["experiment_id"], "status": "DISABLED"})
+            continue
+
+        if args.resume:
+            receipt = latest_green_receipt(job["experiment_id"])
+            if receipt is not None:
+                print(f"[QTR] {matrix_id}: SKIP green {job['experiment_id']} receipt={receipt}")
+                results.append({
+                    "experiment_id": job["experiment_id"],
+                    "status": "SKIPPED_EXISTING_GREEN",
+                    "receipt": str(receipt),
+                })
+                continue
+
+        print(f"[QTR] {matrix_id}: {idx}/{len(matrix['jobs'])} {job['experiment_id']} ({label})")
+        if args.dry_run:
+            results.append({"experiment_id": job["experiment_id"], "status": "DRY_RUN"})
+            continue
+
+        proc = subprocess.run(
+            [str(ROOT / "scripts" / "colab_run_job.sh"), str(job_path)],
+            cwd=ROOT,
+            check=False,
+        )
+        status = "GREEN" if proc.returncode == 0 else "FAILED"
+        results.append({
+            "experiment_id": job["experiment_id"],
+            "status": status,
+            "returncode": proc.returncode,
+        })
+        if proc.returncode and not args.continue_on_error:
+            break
+
+    summary = {
+        "schema_version": 1,
+        "matrix_id": matrix_id,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "dry_run": args.dry_run,
+        "resume": args.resume,
+        "continue_on_error": args.continue_on_error,
+        "results": results,
+        "claim_boundary": matrix["claim_boundary"],
+    }
+    work.mkdir(parents=True, exist_ok=True)
+    (work / "matrix_run.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    failures = [row for row in results if row["status"] == "FAILED"]
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/colab_run_matrix.py
+++ b/scripts/colab_run_matrix.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 from datetime import datetime, timezone
 import json
 from pathlib import Path
@@ -78,14 +79,35 @@ def load_matrix(path: Path) -> dict:
     return matrix
 
 
-def latest_green_receipt(experiment_id: str) -> Path | None:
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def source_head() -> str:
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=ROOT, text=True
+    ).strip()
+
+
+def latest_green_receipt(
+    experiment_id: str, job_path: Path, expected_source_commit: str
+) -> Path | None:
     base = ROOT / "runs" / "hosted" / experiment_id
+    expected_job_sha256 = sha256_file(job_path)
     for path in sorted(base.glob("*/experiment_receipt.json"), reverse=True):
         try:
             receipt = json.loads(path.read_text(encoding="utf-8"))
         except Exception:
             continue
-        if receipt.get("status") == "GREEN_ENGINEERING":
+        if (
+            receipt.get("status") == "GREEN_ENGINEERING"
+            and receipt.get("job_sha256") == expected_job_sha256
+            and receipt.get("source_commit") == expected_source_commit
+        ):
             return path
     return None
 
@@ -105,6 +127,7 @@ def main() -> int:
     jobs_dir.mkdir(parents=True, exist_ok=True)
 
     results = []
+    exact_source_head = source_head()
     for idx, job in enumerate(matrix["jobs"], 1):
         variant = job["resource"]["variant"]
         accel = job["resource"]["accelerator"]
@@ -118,7 +141,9 @@ def main() -> int:
             continue
 
         if args.resume:
-            receipt = latest_green_receipt(job["experiment_id"])
+            receipt = latest_green_receipt(
+                job["experiment_id"], job_path, exact_source_head
+            )
             if receipt is not None:
                 print(f"[QTR] {matrix_id}: SKIP green {job['experiment_id']} receipt={receipt}")
                 results.append({

--- a/scripts/run_qtr_colab_compute_preflight.sh
+++ b/scripts/run_qtr_colab_compute_preflight.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+REBUILD=0
+RESUME=1
+DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --rebuild) REBUILD=1 ;;
+    --no-resume) RESUME=0 ;;
+    --dry-run) DRY_RUN=1 ;;
+    *) echo "unknown option: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+BOOTSTRAP=(bash scripts/bootstrap_colab_runner_env.sh)
+if [[ "$REBUILD" -eq 1 ]]; then
+  BOOTSTRAP+=(--rebuild)
+fi
+"${BOOTSTRAP[@]}"
+
+PY="$ROOT/.venv/bin/python"
+MATRIX_ARGS=()
+if [[ "$RESUME" -eq 1 ]]; then
+  MATRIX_ARGS+=(--resume)
+fi
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  MATRIX_ARGS+=(--dry-run)
+fi
+
+set +e
+"$PY" scripts/colab_run_matrix.py \
+  configs/compute/qtr_colab_runtime_probe_matrix.json \
+  --continue-on-error "${MATRIX_ARGS[@]}"
+RUNTIME_RC=$?
+set -e
+
+"$PY" scripts/colab_run_matrix.py \
+  configs/compute/qtr_compute_requal_001_matrix.json \
+  "${MATRIX_ARGS[@]}"
+
+echo "[QTR] runtime-probe matrix rc=$RUNTIME_RC"
+if [[ "$RUNTIME_RC" -ne 0 ]]; then
+  echo "[QTR] one or more requested Colab resources were unavailable or failed validation; evidence is retained" >&2
+fi
+exit "$RUNTIME_RC"

--- a/tests/test_qtr_colab_compute_001.py
+++ b/tests/test_qtr_colab_compute_001.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+matrix_mod = load_module("qtr_colab_run_matrix", ROOT / "scripts/colab_run_matrix.py")
+probe_mod = load_module("qtr_colab_runtime_probe", ROOT / "reference/qtr_colab_runtime_probe.py")
+requal_mod = load_module("qtr_compute_requal_001", ROOT / "reference/qtr_compute_requal_001.py")
+
+
+def test_runtime_matrix_is_preparation_only_and_no_silent_substitution():
+    matrix = matrix_mod.load_matrix(ROOT / "configs/compute/qtr_colab_runtime_probe_matrix.json")
+    assert len(matrix["jobs"]) == 6
+    assert {job["resource"]["variant"] for job in matrix["jobs"]} == {"CPU", "GPU", "TPU"}
+    assert all(job["scientific_execution_authorized"] is False for job in matrix["jobs"])
+    gpu = next(job for job in matrix["jobs"] if job["resource"]["accelerator"] == "T4")
+    fake = {"observed_variant": "GPU", "observed_accelerator": "NVIDIA L4"}
+    try:
+        probe_mod.validate_requested_runtime(gpu, fake)
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("T4 request accepted silent L4 substitution")
+
+
+def test_c90_candidate_is_frozen_disabled():
+    matrix = matrix_mod.load_matrix(ROOT / "configs/compute/qtr_c90_exact_candidate_matrix.json")
+    assert matrix["status"] == "FROZEN_DISABLED_PENDING_SEPARATE_SCIENTIFIC_AUTHORITY"
+    assert len(matrix["jobs"]) == 1
+    job = matrix["jobs"][0]
+    assert job["enabled"] is False
+    assert job["scientific_execution_authorized"] is False
+    assert job["required_authorization"]["status"] == "UNSATISFIED"
+
+
+def test_x100_entry_count_arithmetic_preserves_temporal_boundary():
+    assert requal_mod.peak_entries(18) == 1 << 19
+    assert requal_mod.peak_entries(25) == 1 << 26
+    assert requal_mod.multiplier_needed(25) == 64
+    assert requal_mod.multiplier_needed(34) == 32768
+    assert requal_mod.multiplier_needed(36) == 131072
+    nominal = 100 * requal_mod.ORIGINAL_PEAK_CAP
+    assert requal_mod.peak_entries(25) <= nominal
+    assert requal_mod.peak_entries(34) > nominal
+
+
+def test_payload_builder_excludes_hosted_outputs():
+    payload = load_module("qtr_build_colab_payload", ROOT / "scripts/build_colab_payload.py")
+    for rel in (
+        "runs/hosted/x/result.json",
+        ".artifacts/bootstrap/a.json",
+        ".venv/bin/python",
+        ".git/config",
+        "__pycache__/x.pyc",
+    ):
+        path = ROOT / rel
+        assert payload.include_path(path) is False
+
+
+def test_work_package_keeps_accelerator_and_scientific_backend_distinct():
+    text = (ROOT / "work-packages/QTR-COLAB-COMPUTE-001.md").read_text(encoding="utf-8")
+    assert "Allocating a GPU or TPU does not cause them to execute on that accelerator." in text
+    assert "separate exact-equivalence" in text
+    assert "QEC-CIRCUIT-003" in text

--- a/tests/test_qtr_colab_compute_001.py
+++ b/tests/test_qtr_colab_compute_001.py
@@ -74,3 +74,42 @@ def test_work_package_keeps_accelerator_and_scientific_backend_distinct():
     assert "Allocating a GPU or TPU does not cause them to execute on that accelerator." in text
     assert "separate exact-equivalence" in text
     assert "QEC-CIRCUIT-003" in text
+
+
+def test_resume_requires_exact_job_digest_and_source_commit(tmp_path):
+    old_root = matrix_mod.ROOT
+    matrix_mod.ROOT = tmp_path
+    try:
+        job_path = tmp_path / "job.json"
+        job_path.write_text('{"a":1}\n', encoding="utf-8")
+        receipt_dir = tmp_path / "runs" / "hosted" / "X" / "001"
+        receipt_dir.mkdir(parents=True)
+        receipt_path = receipt_dir / "experiment_receipt.json"
+        receipt_path.write_text(json.dumps({
+            "status": "GREEN_ENGINEERING",
+            "job_sha256": "stale",
+            "source_commit": "HEAD",
+        }), encoding="utf-8")
+        assert matrix_mod.latest_green_receipt("X", job_path, "HEAD") is None
+        receipt_path.write_text(json.dumps({
+            "status": "GREEN_ENGINEERING",
+            "job_sha256": matrix_mod.sha256_file(job_path),
+            "source_commit": "OLD",
+        }), encoding="utf-8")
+        assert matrix_mod.latest_green_receipt("X", job_path, "HEAD") is None
+        receipt_path.write_text(json.dumps({
+            "status": "GREEN_ENGINEERING",
+            "job_sha256": matrix_mod.sha256_file(job_path),
+            "source_commit": "HEAD",
+        }), encoding="utf-8")
+        assert matrix_mod.latest_green_receipt("X", job_path, "HEAD") == receipt_path
+    finally:
+        matrix_mod.ROOT = old_root
+
+
+def test_host_runner_requires_receipt_and_bundle_before_green():
+    text = (ROOT / "scripts/colab_run_job.sh").read_text(encoding="utf-8")
+    assert "missing experiment receipt" in text
+    assert "missing output bundle" in text
+    assert "receipt source commit mismatch" in text
+    assert "receipt job digest mismatch" in text

--- a/work-packages/QTR-COLAB-COMPUTE-001.md
+++ b/work-packages/QTR-COLAB-COMPUTE-001.md
@@ -38,6 +38,17 @@ bash scripts/bootstrap_colab_runner_env.sh --rebuild
 source .venv/bin/activate
 ```
 
+One-command hosted engineering preflight:
+
+```bash
+bash scripts/run_qtr_colab_compute_preflight.sh --rebuild
+```
+
+This command runs the independent resource-discovery matrix first and the CPU-reference
+compute-envelope prequalification second. It still returns nonzero if any requested
+accelerator is unavailable or fails validation; those failures are retained rather
+than being silently substituted.
+
 ## 3. Runtime probe matrix
 
 The first matrix characterizes requested Colab resources and rejects silent

--- a/work-packages/QTR-COLAB-COMPUTE-001.md
+++ b/work-packages/QTR-COLAB-COMPUTE-001.md
@@ -1,0 +1,161 @@
+# QTR-COLAB-COMPUTE-001 — Hosted CPU/GPU/TPU preparation
+
+Status: `ENGINEERING_PREPARATION_ONLY__NO_NEW_SCIENTIFIC_EXECUTION_AUTHORITY`
+
+Tracking issue: `#88`
+
+Protected preparation base:
+
+`2a53fa9ba6d18220a8469e2d5d667e003d1cdd37`
+
+## 1. Purpose
+
+This package prepares the qLDPC/QEC programme to use Google Colab CPU, GPU, and
+TPU instances without changing any protected scientific result. It adopts the
+K-DIAGNOSTICS host-orchestrated lifecycle: deterministic payload, fresh runtime,
+explicit upload/execute/download/log/stop steps, fail-closed hardware validation,
+durable receipts, and host-side cleanup.
+
+The runner is engineering infrastructure. A green hosted receipt does not itself
+create scientific evidence or promotion authority.
+
+## 2. Host contract
+
+Use Linux or WSL. The preparation pins:
+
+- Python 3.12 for the local runner environment;
+- `google-colab-cli==0.6.0`;
+- `jupyter-kernel-client==0.9.0`;
+- `COLAB_AUTH=oauth2` by default.
+
+Credentials remain in the CLI/user environment and are never included in source
+payloads or receipts.
+
+Bootstrap:
+
+```bash
+bash scripts/bootstrap_colab_runner_env.sh --rebuild
+source .venv/bin/activate
+```
+
+## 3. Runtime probe matrix
+
+The first matrix characterizes requested Colab resources and rejects silent
+substitution:
+
+```bash
+python scripts/colab_run_matrix.py \
+  configs/compute/qtr_colab_runtime_probe_matrix.json \
+  --dry-run
+```
+
+Hosted execution:
+
+```bash
+python scripts/colab_run_matrix.py \
+  configs/compute/qtr_colab_runtime_probe_matrix.json \
+  --continue-on-error
+```
+
+The `--continue-on-error` flag is appropriate for this resource-discovery matrix
+because accelerator quota/availability failures are independent cells. The matrix
+runner remains fail-fast by default for scientific or coupled workloads.
+
+Predeclared cells:
+
+1. CPU/default;
+2. GPU T4;
+3. GPU L4;
+4. GPU A100;
+5. TPU v5e1;
+6. TPU v6e1.
+
+Each cell records requested and observed hardware, host RAM/disk/CPU information,
+optional Torch/JAX device metadata, and a deterministic functional probe. Timing
+fields are engineering diagnostics only.
+
+## 4. Compute-envelope requalification preflight
+
+The second matrix runs only the protected CPU reference structural logic:
+
+```bash
+python scripts/colab_run_matrix.py \
+  configs/compute/qtr_compute_requal_001_matrix.json
+```
+
+It reproduces:
+
+- C72 deterministic min-fill width 18;
+- C90 deterministic min-fill width 25;
+- temporal C18 widths `34/36/36/36` for `R0/R1/R2/R3`.
+
+It then evaluates the nominal `x100` peak-entry envelope without materializing a
+new compiled object. With original peak cap `2^20`, the required multipliers are:
+
+- C72: `0.5x`;
+- C90: `64x`;
+- temporal R0: `32768x`;
+- temporal R1/R2/R3: `131072x`.
+
+Therefore C90 crosses the nominal `x100` entry-count preflight, while the current
+temporal representations do not. This is not yet a physical-memory clearance:
+Colab RAM and representation-specific bytes per retained entry must be checked
+before any exact C90 materialization.
+
+## 5. Frozen C90 candidate
+
+`configs/compute/qtr_c90_exact_candidate_matrix.json` is intentionally disabled.
+
+The runner rejects any attempt to enable its `c90_exact_candidate` cell under
+this preparation contract. A later scientific contract must define:
+
+- the exact enlarged resource envelope;
+- observed runtime and memory prerequisites;
+- exact algebra(s) to compile;
+- materialization stopping rules;
+- selector validation corpus;
+- evidence/receipt schema;
+- review and promotion path.
+
+No code path in this preparation package permits the disabled candidate to run.
+
+## 6. Accelerator semantics
+
+The existing qLDPC/QEC reference algorithms are Python/CPU implementations.
+Allocating a GPU or TPU does not cause them to execute on that accelerator.
+
+Accordingly:
+
+- runtime probes may use GPU/TPU functional kernels;
+- protected QEC structural replay remains `cpu_reference`;
+- any future GPU/TPU scientific kernel requires a separate exact-equivalence
+  certificate against the CPU reference before accelerator results are admissible.
+
+This distinction is written into every job and receipt.
+
+## 7. Artifacts
+
+Each hosted job writes local evidence under:
+
+`runs/hosted/<experiment-id>/<run-id>/`
+
+including, when available:
+
+- deterministic source archive;
+- source manifest;
+- exact job configuration;
+- Colab status;
+- remote stdout/stderr;
+- `experiment_receipt.json`;
+- `gcl_output_bundle.tar.gz`;
+- Colab execution log;
+- cleanup/session readback.
+
+Failed jobs retain the local directory.
+
+## 8. Claim boundary
+
+This package creates no authority for new C90 scientific evidence, mutation of
+`QLDPC-SCALE-001B`, mutation of `QEC-CIRCUIT-002`, adaptive/stochastic order
+search, gate-level `QEC-CIRCUIT-003`, thresholds, scaling laws, runtime/memory
+superiority, hardware-performance claims, `QLDPC-FORGE`, or autonomous search.


### PR DESCRIPTION
## Scope

Engineering preparation under Issue #88 only. This PR ports the proven K-DIAGNOSTICS Colab lifecycle pattern into `QUANTUM-TECHNOLOGIES` and prepares qLDPC/QEC compute-envelope requalification.

Protected base: `2a53fa9ba6d18220a8469e2d5d667e003d1cdd37`.
Current exact preparation head: `5aeb62aefedecdb091d0c12fc8ff03d4e8c85f81`.

## Adds

- deterministic source-payload builder;
- pinned local Colab-runner bootstrap, including explicit isolated-tool PATH binding used by K-DIAGNOSTICS;
- one-job `new/upload/exec/download/log/stop` lifecycle with guaranteed teardown and explicit `.venv/bin/python` / `.venv/bin/colab` invocation;
- exact receipt/bundle readback requirements;
- resumable/fail-fast matrix runner whose `--resume` requires the same job digest and source commit;
- one-command hosted engineering preflight;
- remote CPU/GPU/TPU capability verification with no silent accelerator substitution;
- six-cell runtime probe matrix: CPU, T4, L4, A100, TPU v5e1, TPU v6e1;
- `QTR-COMPUTE-REQUAL-001` engineering preflight reproducing protected C72/C90 and temporal R0-R3 structural widths under a nominal x100 entry-count envelope;
- frozen disabled C90 exact candidate requiring a separate scientific execution authorization;
- tests and work package.

## Scientific boundary

This PR does not create new scientific evidence. Existing protected Python/GF(2) QEC implementations remain `cpu_reference`. Allocating GPU or TPU hardware does not make those kernels accelerator-backed. A future GPU/TPU QEC backend must receive its own exact-equivalence certificate before its results are admissible.

C90 exact compilation/materialization is disabled. `QEC-CIRCUIT-003`, new temporal representations, adaptive/stochastic order search, threshold/scaling/runtime/memory/hardware claims, and `QLDPC-FORGE` remain unauthorized.

No protected scientific registry, manifest, evidence, evaluator, or promotion record is changed.