### PR TITLE
GHOS Stage A: enforce byte-derived execution routing

### DIFF
--- a/.ghos-routing/workflows.json
+++ b/.ghos-routing/workflows.json
@@ -1,0 +1,144 @@
+{
+  "record_type": "GHOS_EXECUTION_ROUTING_REGISTRY",
+  "schema_version": "1.0.0",
+  "repository": "grandchallenge/QUANTUM-TECHNOLOGIES",
+  "controllers": [
+    {
+      "controller_id": "GITHUB_ACTIONS",
+      "executor_class": "PERSISTENT_CONTROLLER",
+      "provider": "github",
+      "durable_wake_mechanism": "repository-bound GitHub Actions event queue",
+      "state_store": "GitHub Actions workflow run and job records bound to repository and commit SHA",
+      "supported_features": [
+        "AUTONOMOUS_WAKE",
+        "EXTERNAL_REUSABLE_JOB",
+        "EXTERNAL_WAIT",
+        "NON_RECONCILABLE_MUTATION",
+        "OPAQUE_EXECUTION",
+        "SCHEDULED",
+        "SECRET_CREDENTIAL",
+        "UNATTENDED_DISPATCH",
+        "WRITE_CAPABLE"
+      ]
+    }
+  ],
+  "workflows": [
+    {
+      "path": ".github/workflows/gcl-conformance.yml",
+      "observed_features": [
+        "EXTERNAL_REUSABLE_JOB",
+        "OPAQUE_EXECUTION"
+      ],
+      "topology": "PERSISTENT_CONTROLLER_REQUIRED",
+      "controller_id": "GITHUB_ACTIONS"
+    },
+    {
+      "path": ".github/workflows/ghos-routing-enforcement-v2.yml",
+      "observed_features": [
+        "OPAQUE_EXECUTION"
+      ],
+      "topology": "PERSISTENT_CONTROLLER_REQUIRED",
+      "controller_id": "GITHUB_ACTIONS"
+    },
+    {
+      "path": ".github/workflows/qtr-c90-exact-requal-001.yml",
+      "observed_features": [
+        "OPAQUE_EXECUTION"
+      ],
+      "topology": "PERSISTENT_CONTROLLER_REQUIRED",
+      "controller_id": "GITHUB_ACTIONS"
+    },
+    {
+      "path": ".github/workflows/qtr-c90-resource-envelope-001.yml",
+      "observed_features": [
+        "OPAQUE_EXECUTION"
+      ],
+      "topology": "PERSISTENT_CONTROLLER_REQUIRED",
+      "controller_id": "GITHUB_ACTIONS"
+    },
+    {
+      "path": ".github/workflows/qtr-c90-retained-bound-001.yml",
+      "observed_features": [
+        "OPAQUE_EXECUTION"
+      ],
+      "topology": "PERSISTENT_CONTROLLER_REQUIRED",
+      "controller_id": "GITHUB_ACTIONS"
+    },
+    {
+      "path": ".github/workflows/qtr-c90-structure-001.yml",
+      "observed_features": [
+        "OPAQUE_EXECUTION"
+      ],
+      "topology": "PERSISTENT_CONTROLLER_REQUIRED",
+      "controller_id": "GITHUB_ACTIONS"
+    },
+    {
+      "path": ".github/workflows/qtr-qec-circuit-001.yml",
+      "observed_features": [
+        "OPAQUE_EXECUTION"
+      ],
+      "topology": "PERSISTENT_CONTROLLER_REQUIRED",
+      "controller_id": "GITHUB_ACTIONS"
+    },
+    {
+      "path": ".github/workflows/qtr-qec-circuit-002.yml",
+      "observed_features": [
+        "OPAQUE_EXECUTION"
+      ],
+      "topology": "PERSISTENT_CONTROLLER_REQUIRED",
+      "controller_id": "GITHUB_ACTIONS"
+    },
+    {
+      "path": ".github/workflows/qtr-tcm-c72-interface-001-aggregate.yml",
+      "observed_features": [
+        "OPAQUE_EXECUTION",
+        "SECRET_CREDENTIAL",
+        "WRITE_CAPABLE"
+      ],
+      "topology": "PERSISTENT_CONTROLLER_REQUIRED",
+      "controller_id": "GITHUB_ACTIONS"
+    },
+    {
+      "path": ".github/workflows/qtr-tcm-c72-interface-001-execute.yml",
+      "observed_features": [
+        "OPAQUE_EXECUTION"
+      ],
+      "topology": "PERSISTENT_CONTROLLER_REQUIRED",
+      "controller_id": "GITHUB_ACTIONS"
+    },
+    {
+      "path": ".github/workflows/qtr-tcm-c72-interface-001.yml",
+      "observed_features": [
+        "OPAQUE_EXECUTION"
+      ],
+      "topology": "PERSISTENT_CONTROLLER_REQUIRED",
+      "controller_id": "GITHUB_ACTIONS"
+    },
+    {
+      "path": ".github/workflows/qtr-tcm-qdec-compare-001.yml",
+      "observed_features": [
+        "OPAQUE_EXECUTION"
+      ],
+      "topology": "PERSISTENT_CONTROLLER_REQUIRED",
+      "controller_id": "GITHUB_ACTIONS"
+    },
+    {
+      "path": ".github/workflows/qtr-validation.yml",
+      "observed_features": [
+        "OPAQUE_EXECUTION"
+      ],
+      "topology": "PERSISTENT_CONTROLLER_REQUIRED",
+      "controller_id": "GITHUB_ACTIONS"
+    }
+  ],
+  "claim_boundaries": {
+    "constitutional": false,
+    "merge": false,
+    "certification": false,
+    "production": false,
+    "publication": false,
+    "mathematical_claim": false,
+    "claim_promotion": false,
+    "commercial": false
+  }
+}

--- a/.github/workflows/ghos-routing-enforcement-v2.yml
+++ b/.github/workflows/ghos-routing-enforcement-v2.yml
@@ -1,0 +1,97 @@
+name: GH-OS routing enforcement
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ghos-routing-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  routing-enforcement:
+    name: routing-enforcement
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Materialize protected and effective candidate routing bytes as inert public data
+        shell: bash
+        run: |
+          python - <<'PY'
+          import io
+          import json
+          import os
+          import pathlib
+          import tarfile
+          import urllib.request
+
+          event = json.loads(pathlib.Path(os.environ["GITHUB_EVENT_PATH"]).read_text(encoding="utf-8"))
+          pull = event["pull_request"]
+          base_repository = pull["base"]["repo"]["full_name"]
+          merge_ref = f"refs/pull/{pull['number']}/merge"
+          snapshots = {
+              "protected-base": (base_repository, pull["base"]["sha"]),
+              "candidate": (base_repository, merge_ref),
+          }
+
+          for destination, (repository, revision) in snapshots.items():
+              url = f"https://codeload.github.com/{repository}/tar.gz/{revision}"
+              request = urllib.request.Request(url, headers={"User-Agent": "gcl-ghos-routing-gate"})
+              with urllib.request.urlopen(request, timeout=60) as response:
+                  archive = response.read()
+
+              root = pathlib.Path(destination)
+              root.mkdir(parents=True, exist_ok=True)
+              with tarfile.open(fileobj=io.BytesIO(archive), mode="r:gz") as bundle:
+                  for member in bundle.getmembers():
+                      parts = pathlib.PurePosixPath(member.name).parts
+                      if len(parts) < 2:
+                          continue
+                      relative = pathlib.PurePosixPath(*parts[1:])
+                      text = relative.as_posix()
+                      relevant = (
+                          text == ".ghos-routing/workflows.json"
+                          or text.startswith(".github/workflows/")
+                      )
+                      if not relevant:
+                          continue
+                      if ".." in relative.parts or relative.is_absolute():
+                          raise SystemExit(f"unsafe archive path: {text}")
+                      if not member.isfile():
+                          raise SystemExit(f"routing input must be a regular file: {text}")
+                      source = bundle.extractfile(member)
+                      if source is None:
+                          raise SystemExit(f"unable to read routing input: {text}")
+                      target = root.joinpath(*relative.parts)
+                      target.parent.mkdir(parents=True, exist_ok=True)
+                      target.write_bytes(source.read())
+          PY
+      - name: Reject enforcement self-modification
+        shell: bash
+        run: |
+          cmp --silent \
+            protected-base/.github/workflows/ghos-routing-enforcement-v2.yml \
+            candidate/.github/workflows/ghos-routing-enforcement-v2.yml || {
+              echo "GH-OS routing enforcement workflow may not be changed through an ordinary candidate PR"
+              exit 1
+            }
+      - name: Fetch and verify externally governed routing gate
+        shell: bash
+        run: |
+          mkdir -p policy-runtime/scripts
+          curl --fail --location --retry 3 \
+            https://raw.githubusercontent.com/grandchallenge/.github/ef1cce6029233a68cf46063cea2384772fcae613/scripts/ghos_execution_routing_gate.py \
+            --output policy-runtime/scripts/ghos_execution_routing_gate.py
+          echo "fc0a9a4d20de72e9fbc04c8cd54cffc3a6e4657fb09e7978b360616bd5e94a17  policy-runtime/scripts/ghos_execution_routing_gate.py" | sha256sum --check --strict
+      - name: Install routing gate dependency
+        run: |
+          python -m pip install --disable-pip-version-check --no-deps --only-binary=:all: PyYAML==6.0.3
+      - name: Execute external gate against effective candidate bytes
+        shell: bash
+        run: |
+          python -c 'import runpy,sys; runpy.run_path(sys.argv.pop(1), run_name="__main__")' policy-runtime/scripts/ghos_execution_routing_gate.py \
+            --root candidate \
+            --repository "$GITHUB_REPOSITORY"


### PR DESCRIPTION
Stage A for GHOS-ESTATE-ROLLOUT-001 / QUANTUM-TECHNOLOGIES #116.

Exact protected base: `aa53dc3c0e99c39f766f4ccb0c0d0629cd9093db`.
Exact candidate head: `c92279f62e169b899f1642bb0f5b386088300006`.

Candidate delta is exactly two added files and no edits to the 12 existing protected workflows:
- `.ghos-routing/workflows.json`
- `.github/workflows/ghos-routing-enforcement-v2.yml`

Registry covers all 13 candidate workflows (12 pre-existing plus enforcement). All derive `PERSISTENT_CONTROLLER_REQUIRED` and bind only to admitted controller `GITHUB_ACTIONS`. The only non-generic feature cases are:
- `gcl-conformance.yml`: `EXTERNAL_REUSABLE_JOB`, `OPAQUE_EXECUTION`
- `qtr-tcm-c72-interface-001-aggregate.yml`: `OPAQUE_EXECUTION`, `SECRET_CREDENTIAL`, `WRITE_CAPABLE`
- all remaining protected workflows and enforcement: `OPAQUE_EXECUTION`

The C72 aggregate feature classification is literal under the pinned gate because its job contains `${{ github.token }}` and `gh api`; this is routing classification only, not an authority promotion.

Enforcement is the already-admitted candidate-independent implementation: protected-base `pull_request_target`, read-only contents permission, candidate bytes inert, enforcement self-modification rejected, external gate pinned to `grandchallenge/.github@ef1cce6029233a68cf46063cea2384772fcae613`, gate SHA-256 `fc0a9a4d20de72e9fbc04c8cd54cffc3a6e4657fb09e7978b360616bd5e94a17`, dependency `PyYAML==6.0.3`.

Live ruleset `20106953` remains untouched in Stage A: active, strict, zero-bypass, required contexts exactly `validate`, `policy`, `security / action-policy`. Tag ruleset `20355165` remains untouched.

No constitutional, mathematical, certification, provenance, publication, production, scientific, physical, novelty, patentability, mechanical, manufacturing, or commercial authority is enlarged.