### PR TITLE
GHOS hostile unregistered workflow probe — DO NOT MERGE

### DIFF
--- a/.github/workflows/ghos-hostile-unregistered-probe.yml
+++ b/.github/workflows/ghos-hostile-unregistered-probe.yml
@@ -1,0 +1,15 @@
+name: GHOS hostile unregistered workflow probe
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  inert-probe:
+    if: ${{ false }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Inert marker
+        run: echo "This hostile probe job must never execute; routing enforcement should reject the unregistered workflow first."


### PR DESCRIPTION
Stage C hostile proof for GHOS-ESTATE-ROLLOUT-001 / QUANTUM-TECHNOLOGIES #116.

Exact protected base: `4f0e59cfc16322e5949b388b6c34fdb0176e2c07`.
Exact hostile head: `d53844e2897926e6ea72eb203c37ab26c8cbcd30`.

Delta is exactly one syntactically valid but UNREGISTERED workflow: `.github/workflows/ghos-hostile-unregistered-probe.yml`.

The workflow is inert: manual-dispatch only, `permissions: contents: read`, and its sole job is disabled with `if: false`. It contains no secrets, no write permission, no mutation, and must not be executed as candidate code by the protected-base routing gate.

Expected result: protected-base `routing-enforcement` evaluates candidate routing bytes as inert data and fails on workflow registry coverage mismatch. Because ruleset `20106953` now requires `routing-enforcement` under `strict: true` with zero bypass, this PR must remain structurally blocked and then be closed unmerged.